### PR TITLE
CoffeeScript

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -572,57 +572,30 @@ module Tilt
   # http://coffeescript.org/
   #
   # CoffeeScript templates do not support object scopes, locals, or yield.
-  #
-  # Requires `coffee` binary be in PATH or specified with `coffee_bin`.
   class CoffeeScriptTemplate < Template
-    @@coffee_bin = nil
-    @@default_nowrap = true
+    @@default_no_wrap = true
 
-    def self.locate_coffee_bin
-      out = `which coffee`
-      if $?.success?
-        out.chomp
-      else
-        raise LoadError, "could not find `coffee` in PATH"
-      end
+    def self.default_no_wrap
+      @@default_no_wrap
     end
 
-    def self.coffee_bin
-      @@coffee_bin ||= locate_coffee_bin
+    def self.default_no_wrap=(value)
+      @@default_no_wrap = value
     end
 
-    def self.coffee_bin=(path)
-      @@coffee_bin = path
-    end
-
-    def self.default_nowrap
-      @@default_nowrap
-    end
-
-    def self.default_nowrap=(value)
-      @@default_nowrap = value
+    def initialize_engine
+      return if defined? ::CoffeeScript
+      require_template_library 'coffee_script'
     end
 
     def prepare
-      @nowrap = options.key?(:nowrap) ? options[:nowrap] :
-        self.class.default_nowrap
+      @no_wrap = options.key?(:no_wrap) ? options[:no_wrap] :
+        self.class.default_no_wrap
     end
 
     def evaluate(scope, locals, &block)
-      @output ||= coffee(data)
+      @output ||= CoffeeScript.compile(data, :no_wrap => @no_wrap)
     end
-
-    private
-      def coffee(input)
-        command = "#{self.class.coffee_bin} -sp"
-        command += " --no-wrap" if @nowrap
-
-        IO.popen(command, "w+") do |f|
-          f << input
-          f.close_write
-          f.read
-        end
-      end
   end
   register 'coffee', CoffeeScriptTemplate
 

--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -2,7 +2,7 @@ require 'contest'
 require 'tilt'
 
 begin
-  Tilt::CoffeeScriptTemplate.locate_coffee_bin
+  require 'coffee_script'
 
   class CoffeeScriptTemplateTest < Test::Unit::TestCase
     test "is registered for '.coffee' files" do
@@ -15,7 +15,7 @@ begin
     end
 
     test "enabling coffee-script wrapper" do
-      template = Tilt::CoffeeScriptTemplate.new(:nowrap => false) { |t| "puts 'Hello, World!'\n" }
+      template = Tilt::CoffeeScriptTemplate.new(:no_wrap => false) { |t| "puts 'Hello, World!'\n" }
       assert_equal "(function() {\n  puts('Hello, World!');\n})();\n", template.render
     end
   end


### PR DESCRIPTION
Adds CoffeeScriptTemplate template engine.

The `coffee-script` gem has been re-released as a Ruby wrapper around `coffee` binary.
