### PR TITLE
BlueClothTemplate

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -765,15 +765,6 @@ module Tilt
       @output ||= @engine.to_html
     end
   end
-  
-  begin
-    require 'rdiscount'
-  rescue LoadError
-    # Only register BlueCloth if we have RDiscount.
-    register 'markdown', BlueClothTemplate
-    register 'mkd', BlueClothTemplate
-    register 'md', BlueClothTemplate
-  end
 
 
   # RedCloth implementation. See:

--- a/test/tilt_blueclothtemplate_test.rb
+++ b/test/tilt_blueclothtemplate_test.rb
@@ -5,6 +5,19 @@ begin
   require 'bluecloth'
 
   class BlueClothTemplateTest < Test::Unit::TestCase
+    setup do
+      Tilt.register('markdown', Tilt::BlueClothTemplate)
+      Tilt.register('md', Tilt::BlueClothTemplate)
+      Tilt.register('mkd', Tilt::BlueClothTemplate)
+    end
+    
+    teardown do
+      # Need to revert to RDiscount, otherwise the RDiscount test will fail
+      Tilt.register('markdown', Tilt::RDiscountTemplate)
+      Tilt.register('md', Tilt::RDiscountTemplate)
+      Tilt.register('mkd', Tilt::RDiscountTemplate)
+    end
+    
     test "registered for '.markdown' files unless RDiscount is loaded" do
       unless defined?(RDiscount)
         assert_equal Tilt::BlueClothTemplate, Tilt['test.markdown']


### PR DESCRIPTION
I added BlueClothTemplate. It only registers for markdown stuff if RDiscount isn't installed. Please change if this isn't the desired way of doing it.
