### PR TITLE
Make coffee-script tests pass, again

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -587,7 +587,7 @@ module Tilt
     end
 
     def evaluate(scope, locals, &block)
-      @output ||= CoffeeScript.compile(data, :no_wrap => @no_wrap)
+      @output ||= CoffeeScript.compile(data, :wrap => !@no_wrap)
     end
   end
   register 'coffee', CoffeeScriptTemplate


### PR DESCRIPTION
The coffee-script gem changed behavior: it was impossible to to get a wrapped result with Tilt. This affected Sinatra.
