### PR TITLE
Encoding::CompatibilityError with Ruby 1.9 + ERB when multi-byte string is used in both template and variable

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -189,9 +189,16 @@ module Tilt
     # easier and more appropriate.
     def precompiled(locals)
       preamble = precompiled_preamble(locals)
+      template = precompiled_template(locals)
+      magic_comment = extract_magic_comment(template)
+      if magic_comment
+        # Magic comment e.g. "# coding: utf-8" has to be in the first line.
+        # So we copy the magic comment to the first line.
+        preamble = magic_comment + "\n" + preamble
+      end
       parts = [
         preamble,
-        precompiled_template(locals),
+        template,
         precompiled_postamble(locals)
       ]
       [parts.join("\n"), preamble.count("\n") + 1]
@@ -280,6 +287,10 @@ module Tilt
       method = TOPOBJECT.instance_method(method_name)
       TOPOBJECT.class_eval { remove_method(method_name) }
       method
+    end
+
+    def extract_magic_comment(script)
+      script.slice(/\A[ \t]*\#.*coding\s*[=:]\s*([[:alnum:]\-_]+).*$/)
     end
 
     # Special case Ruby 1.9.1's broken yield.


### PR DESCRIPTION
Here's script to reproduce the issue:
https://gist.github.com/728823

Here's output of the script with tilt 1.1:

```
/tmp/template20101205-22819-1ljrpwf:2:in `concat': incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)
    from /tmp/template20101205-22819-1ljrpwf:2:in `evaluate_source'
    from /usr/local/lib/ruby/gems/1.9.1/gems/tilt-1.1/lib/tilt.rb:254:in `instance_eval'
    from /usr/local/lib/ruby/gems/1.9.1/gems/tilt-1.1/lib/tilt.rb:254:in `evaluate_source'
    from /usr/local/lib/ruby/gems/1.9.1/gems/tilt-1.1/lib/tilt.rb:195:in `evaluate'
    from /usr/local/lib/ruby/gems/1.9.1/gems/tilt-1.1/lib/tilt.rb:128:in `render'
    from test.rb:15:in `<main>'
```

Issue here is that:
- ERB#src correctly outputs magic comment e.g. "# coding: utf-8" based on either magic comment in ERB template or encoding of the template string
- eval() correctly handles magic comment, but it must be in the first line
- But Tilt add some script (preamble) before the output of ERB#src, so the magic comment no longer works

Solution in this change is to copy the magic comment to the first line.
It looks like https://github.com/rtomayko/tilt/pull/45 solves the same issue, but this patch might be slightly simpler and more general (because it should also work for other template engines which output magic comment if any).
