### PR TITLE
Default encoding

### DIFF
--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -198,13 +198,23 @@ class CompiledERBTemplateTest < Test::Unit::TestCase
     assert_equal "\nhello\n", template.render(Scope.new)
   end
 
-  test "encoding" do
+  test "encoding with magic comment" do
     f = Tempfile.open("template")
     f.puts('<%# coding: UTF-8 %>')
     f.puts('ふが <%= @hoge %>')
     f.close()
     @hoge = "ほげ"
     erb = Tilt['erb'].new(f.path)
+    3.times { erb.render(self) }
+    f.delete
+  end
+
+  test "encoding with :default_encoding" do
+    f = Tempfile.open("template")
+    f.puts('ふが <%= @hoge %>')
+    f.close()
+    @hoge = "ほげ"
+    erb = Tilt['erb'].new(f.path, :default_encoding => 'UTF-8')
     3.times { erb.render(self) }
     f.delete
   end


### PR DESCRIPTION
This would be useful for Sinatra where we are already aware of a default encoding (necessary to handle incoming params).

This patch assumes #50 has been merged (hence the first commit).
