### PR TITLE
Kramdown support

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -773,6 +773,25 @@ module Tilt
   end
 
 
+  # Kramdown Markdown implementation. See:
+  # http://kramdown.rubyforge.org/
+  class KramdownTemplate < Template
+    def initialize_engine
+      return if defined? ::Kramdown
+      require_template_library 'kramdown'
+    end
+
+    def prepare
+      @engine = Kramdown::Document.new(data, options)
+      @output = nil
+    end
+
+    def evaluate(scope, locals, &block)
+      @output ||= @engine.to_html
+    end
+  end
+
+
   # RedCloth implementation. See:
   # http://redcloth.org/
   class RedClothTemplate < Template


### PR DESCRIPTION
Added preliminary support for the [Karmdown](http://kramdown.rubyforge.org/) markdown processor. Kramdown is a relatively new and fast pure-Ruby markdown processor, so I defined it after the BlueClothTemplate and RDiscountTemplate. Kramdown should be preferred over Maruku, an older and buggier pure-Ruby markdown processor.

Also fixed a typo in the documentation for BlueClothTemplate.
