### PR TITLE
Pass through buffer output variable name to Erubis

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -454,7 +454,7 @@ module Tilt
     end
 
     def precompiled_preamble(locals)
-      [super, "#{@outvar} = ''"].join("\n")
+      [super, "#{@outvar} = _buf = ''"].join("\n")
     end
 
     def precompiled_postamble(locals)


### PR DESCRIPTION
Working with makoto kuwata, there is a new patch to Erubis that supports specifying the output variable name:

https://github.com/kwatch/erubis/commit/d735e2255ce102719cff1530fb6c138a76c62e4e

New version of Erubis (2.7) will be released in a few days to a week. This is to keep the output variable consistent within Tilt and Erubis itself. Particularly I use this to enable Padrino to properly capture / concat to the Erubis buffer the same way as in ERB.

Tests all pass for tilt as of using latest erubis from source: 

```
$ git clone https://github.com/kwatch/erubis.git
$ ruby setup.rb config
$ ruby setup.rb setup
# sudo ruby setup.rb install  (may require root privilege)
```

Should probably merge this after Erubis 2.7 is released.
