### PR TITLE
Fixes erubis 'bufname' to 'bufvar'

### DIFF
--- a/lib/tilt/erb.rb
+++ b/lib/tilt/erb.rb
@@ -82,7 +82,7 @@ module Tilt
 
     def prepare
       @outvar = options.delete(:outvar) || self.class.default_output_variable
-      @options.merge!(:preamble => false, :postamble => false, :bufname => @outvar)
+      @options.merge!(:preamble => false, :postamble => false, :bufvar => @outvar)
       engine_class = options.delete(:engine_class)
       engine_class = ::Erubis::EscapedEruby if options.delete(:escape_html)
       @engine = (engine_class || ::Erubis::Eruby).new(data, options)


### PR DESCRIPTION
Thanks for pulling in my original commit. Since, Erubis 2.7.0 has been officially released. Although in further discussions with Makoto, the option name was changed here: https://github.com/kwatch/erubis/commit/cd532bfac8127d5526c5d30f5e1d55ff6ff09b1d

Tests still pass with Erubis of all versions but with >= 2.7.0 the buffer variable will be respected.
