### PR TITLE
.prefer should only override extensions it is registered for

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -39,8 +39,8 @@ module Tilt
   #   Tilt.prefer(Tilt::RDiscountTemplate, '.md')
   def self.prefer(template_class, *extensions)
     if extensions.empty?
-      mappings.each do |ext, klass|
-        @preferred_mappings[ext] = template_class
+      mappings.each do |ext, klasses|
+        @preferred_mappings[ext] = template_class if klasses.include? template_class
       end
     else
       extensions.each do |ext|

--- a/test/tilt_fallback_test.rb
+++ b/test/tilt_fallback_test.rb
@@ -109,5 +109,14 @@ class TiltFallbackTest < Test::Unit::TestCase
       assert_equal FailTemplate, template
     end
   end
+  
+  test ".prefer should only override extensions the preferred library is registered for"  do
+    Tilt.register("md", WinTemplate)
+    Tilt.register("mkd", FailTemplate)
+    Tilt.register("mkd", WinTemplate)
+    Tilt.prefer(FailTemplate)
+    assert_equal FailTemplate, Tilt["mkd"]
+    assert_equal WinTemplate, Tilt["md"]
+  end
 end
 


### PR DESCRIPTION
Tilt.prefer was preferring the template for every extension. This checks that the template is registered for the extension before adding it to the prefer list.

If there is anything I should do differently in the future, let me know (politely :P)
