### PR TITLE
fix Tilt.prefer(engine)

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -39,7 +39,8 @@ module Tilt
   #   Tilt.prefer(Tilt::RDiscountTemplate, '.md')
   def self.prefer(template_class, *extensions)
     if extensions.empty?
-      mappings.each do |ext, klass|
+      mappings.each do |ext, klasses|
+        next unless klasses.include? template_class
         @preferred_mappings[ext] = template_class
       end
     else

--- a/test/tilt_fallback_test.rb
+++ b/test/tilt_fallback_test.rb
@@ -109,5 +109,24 @@ class TiltFallbackTest < Test::Unit::TestCase
       assert_equal FailTemplate, template
     end
   end
+
+  test ".prefer with no extension should only register for extensions associated with the engine" do
+    extensions = %w[md mkd markdown]
+
+    extensions.each do |ext|
+      Tilt.register(ext, FailTemplate)
+      Tilt.register(ext, WinTemplate)
+    end
+
+    Tilt.register('foo', WinTemplate)
+    Tilt.prefer(FailTemplate)
+
+    extensions.each do |ext|
+      template = Tilt[ext]
+      assert_equal FailTemplate, template
+    end
+
+    assert_equal WinTemplate, Tilt['foo']
+  end
 end
 


### PR DESCRIPTION
Currently `Tilt.prefer SomeEngine` will register `SomeEngine` for _all_ extensions.
