### PR TITLE
Use Sass::Plugin.engine_options to allow sass to be configurable

### DIFF
--- a/lib/tilt/css.rb
+++ b/lib/tilt/css.rb
@@ -9,15 +9,16 @@ module Tilt
     self.default_mime_type = 'text/css'
 
     def self.engine_initialized?
-      defined? ::Sass::Engine
+      defined?(::Sass::Engine) && defined?(::Sass::Plugin)
     end
 
     def initialize_engine
       require_template_library 'sass'
+      require_template_library 'sass/plugin'
     end
 
     def prepare
-      @engine = ::Sass::Engine.new(data, sass_options)
+      @engine = ::Sass::Engine.new(data, ::Sass::Plugin.engine_options(sass_options))
     end
 
     def evaluate(scope, locals, &block)

--- a/test/tilt_sasstemplate_test.rb
+++ b/test/tilt_sasstemplate_test.rb
@@ -19,6 +19,17 @@ begin
       template = Tilt::SassTemplate.new { |t| "#main\n  :background-color #0000f1" }
       3.times { assert_equal "#main {\n  background-color: #0000f1; }\n", template.render }
     end
+
+    test "uses configuration from Sass::Plugin.engine_options" do
+      begin
+        orig_style = Sass::Plugin.options[:style]
+        Sass::Plugin.options[:style] = :compressed
+        template = Tilt::SassTemplate.new { |t| "#main\n  :background-color #0000f1" }
+        assert_equal "#main{background-color:#0000f1}\n", template.render
+      ensure
+        Sass::Plugin.options[:style] = orig_style
+      end
+    end
   end
 
   class ScssTemplateTest < Test::Unit::TestCase


### PR DESCRIPTION
Hi guys

Just started new application on edge rails and I'd like to use compass there, but it doesn't work since rails 3.1 bundled with sprockets (and tilt as dependency). This patch allows customization via `engine_options` method.

Thanks
