### PR TITLE
Flip CoffeeScript bare option back to true by default

### DIFF
--- a/lib/tilt/coffee.rb
+++ b/lib/tilt/coffee.rb
@@ -8,7 +8,7 @@ module Tilt
   class CoffeeScriptTemplate < Template
     self.default_mime_type = 'application/javascript'
 
-    @@default_bare = true
+    @@default_bare = false
 
     def self.default_bare
       @@default_bare

--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -40,7 +40,8 @@ begin
 
       test "no options" do
         template = Tilt::CoffeeScriptTemplate.new { |t| "puts 'Hello, World!'\n" }
-        assert_equal "puts('Hello, World!');", template.render
+        assert_match "puts('Hello, World!');", template.render
+        assert_match "(function() {", template.render
       end
 
       test "overridden by :bare" do


### PR DESCRIPTION
Its embarrassing that it took me this long to realize I fucked up the `default_bare` option.

In 882b46686decbced239d85a1331a328d2c5f8a78 I switched from `no_wrap` to `bare` but changed the default value from `false` to `true`. `no_wrap` and `bare` are aliases so the value should have just been left alone.

I think we should consider this a regression and flip it back to its rightful value. Its a much better default regardless.
