### PR TITLE
Add Encoding.default_external to test/tile_erbtemplate_test.rb

### DIFF
--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -1,4 +1,7 @@
 # coding: utf-8
+if RUBY_VERSION >= '1.9.1'
+  Encoding.default_external = "UTF-8"
+end
 require 'contest'
 require 'tilt'
 require 'erb'


### PR DESCRIPTION
When LANG is not set(LANG=C) or diffenent from UTF-8 , 
tilt_erbtemplate_test.rb is failed because Ruby1.9.1 can't handling UTF-8 charactor.

This patch add Encoding.default_external for MRI >= '1.9.1'

Signed-off-by: Youhei SASAKI uwabami@gfd-dennou.org
