### PR TITLE
This caused errors in the gem specification which is loud everytime the gem is called

### DIFF
--- a/tilt.gemspec
+++ b/tilt.gemspec
@@ -4,7 +4,6 @@ Gem::Specification.new do |s|
 
   s.name = 'tilt'
   s.version = '1.3.3'
-  s.date = '2011-08-25'
 
   s.description = "Generic interface to multiple Ruby template engines"
   s.summary     = s.description


### PR DESCRIPTION
Here's the error that would print:

Invalid gemspec in [/Users/asenchi/.rvm/gems/ruby-1.9.2-p290/specifications/tilt-1.3.3.gemspec]: invalid date format in specification: "2011-08-25 00:00:00.000000000Z"
