### PR TITLE
Never source eval, always compile source generating templates

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -193,29 +193,6 @@ module Tilt
     end
 
   private
-    # Evaluate the template source in the context of the scope object.
-    def evaluate_source(scope, locals, &block)
-      source, offset = precompiled(locals)
-      scope.instance_eval(source, eval_file, line - offset)
-    end
-
-    # JRuby doesn't allow Object#instance_eval to yield to the block it's
-    # closed over. This is by design and (ostensibly) something that will
-    # change in MRI, though no current MRI version tested (1.8.6 - 1.9.2)
-    # exhibits the behavior. More info here:
-    #
-    # http://jira.codehaus.org/browse/JRUBY-2599
-    #
-    # We redefine evaluate_source to work around this issue.
-    if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
-      undef evaluate_source
-      def evaluate_source(scope, locals, &block)
-        source, offset = precompiled(locals)
-        file, lineno = eval_file, (line - offset)
-        scope.instance_eval { Kernel::eval(source, binding, file, lineno) }
-      end
-    end
-
     def compile_template_method(locals)
       source, offset = precompiled(locals)
       method_name = "__tilt_#{Thread.current.object_id.abs}"


### PR DESCRIPTION
This came up in a sidebar discussion with @josevalim. The compiled / unbound method version of a template currently runs only after the second call to render. The first and second invocations are source eval'd. This went in with the original unbound method stuff (#43) for performance reasons:

> Only compiles the template source the second time (so we don't punish users who doesn't cache the Template-instance).

I think it's probably not worth worrying about this case. Code that's creating a new Template instance for the same template over and over is clearly not very concerned with performance in the first place. The extra allocations to create the new method is probably not much more than eval'ing the source. And worst of all this is hiding bugs that weren't surfaced in the tests because they very rarely run a template more than once.

/cc @judofyr - What do you think? Can we get away with always compiling?
