### PR TITLE
rdoc 3.10 autoloads everything, so you _have_ to require 'rdoc' directly.

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -407,9 +407,9 @@ library.
 
 ### Usage
 
-__NOTE:__ It's suggested that your program `require 'rdoc/markup'` and
-`require 'rdoc/markup/to_html'` at load time when using this template
-engine in a threaded environment.
+__NOTE:__ It's suggested that your program `require 'rdoc'`,
+`require 'rdoc/markup'`, and `require 'rdoc/markup/to_html'` at load time
+when using this template engine in a threaded environment.
 
 ### See also
 

--- a/lib/tilt/rdoc.rb
+++ b/lib/tilt/rdoc.rb
@@ -4,9 +4,9 @@ module Tilt
   # RDoc template. See:
   # http://rdoc.rubyforge.org/
   #
-  # It's suggested that your program require 'rdoc/markup' and
-  # 'rdoc/markup/to_html' at load time when using this template
-  # engine.
+  # It's suggested that your program `require 'rdoc/markup'` and
+  # `require 'rdoc/markup/to_html'` at load time when using this template
+  # engine in a threaded environment.
   class RDocTemplate < Template
     self.default_mime_type = 'text/html'
 
@@ -15,6 +15,7 @@ module Tilt
     end
 
     def initialize_engine
+      require_template_library 'rdoc'
       require_template_library 'rdoc/markup'
       require_template_library 'rdoc/markup/to_html'
     end

--- a/test/tilt_rdoctemplate_test.rb
+++ b/test/tilt_rdoctemplate_test.rb
@@ -2,6 +2,7 @@ require 'contest'
 require 'tilt'
 
 begin
+  require 'rdoc'
   require 'rdoc/markup'
   require 'rdoc/markup/to_html'
   class RDocTemplateTest < Test::Unit::TestCase


### PR DESCRIPTION
rdoc 3.10 autoloads everything, so you _have_ to require 'rdoc' directly. leave other requires for backwards compat
