### PR TITLE
Fixed minor coffeescript test failures.

### DIFF
--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -23,15 +23,16 @@ begin
       str = "puts 'Hello, World!'\n"
 
       template = Tilt::CoffeeScriptTemplate.new(:bare => true) { str }
-      assert_equal "puts('Hello, World!');", template.render
+      assert_equal "\nputs('Hello, World!');\n", template.render
 
       template2 = Tilt::CoffeeScriptTemplate.new(:no_wrap => true) { str}
-      assert_equal "puts('Hello, World!');", template.render
+      assert_equal "\nputs('Hello, World!');\n", template.render
     end
 
     context "disabling coffee-script wrapper globally" do
       setup do
         @bare = Tilt::CoffeeScriptTemplate.default_bare
+        Tilt::CoffeeScriptTemplate.default_bare = true
       end
 
       teardown do
@@ -40,18 +41,17 @@ begin
 
       test "no options" do
         template = Tilt::CoffeeScriptTemplate.new { |t| "puts 'Hello, World!'\n" }
-        assert_match "puts('Hello, World!');", template.render
-        assert_match "(function() {", template.render
+        assert_equal "\nputs('Hello, World!');\n", template.render
       end
 
       test "overridden by :bare" do
         template = Tilt::CoffeeScriptTemplate.new(:bare => false) { "puts 'Hello, World!'\n" }
-        assert_not_equal "puts('Hello, World!');", template.render
+        assert_not_equal "\nputs('Hello, World!');\n", template.render
       end
 
       test "overridden by :no_wrap" do
         template = Tilt::CoffeeScriptTemplate.new(:no_wrap => false) { "puts 'Hello, World!'\n" }
-        assert_not_equal "puts('Hello, World!');", template.render
+        assert_not_equal "\nputs('Hello, World!');\n", template.render
       end
     end
   end


### PR DESCRIPTION
Hi
the coffeescript-tests seemed to fail for small things.
Could somebody please have a look at the "disabling coffee-script wrapper globally"-section?
As I read it, it was not disabling the wrapper globally.

Thanks
