### PR TITLE
Yajl test now accept hashes even if the order is different.

### DIFF
--- a/test/tilt_yajltemplate_test.rb
+++ b/test/tilt_yajltemplate_test.rb
@@ -73,7 +73,8 @@ begin
         json[:integer] = four
         nil
       } }
-      assert_equal '{"string":"hello","integer":4}', template.render
+      result = template.render
+      assert( (result == '{"string":"hello","integer":4}') || (result == '{"integer":4,"string":"hello"}') )
     end
 
     test "option callback" do


### PR DESCRIPTION
Ruby 1.8.7p357 changed the hashing mechanism a bit. As a result a yajl-test fails in that version due to a changed key-order in a hash.
