### PR TITLE
adjusted specs to RDoc >= 3.10 ( which outputs header ids )

### DIFF
--- a/test/tilt_rdoctemplate_test.rb
+++ b/test/tilt_rdoctemplate_test.rb
@@ -12,12 +12,12 @@ begin
 
     test "preparing and evaluating the template with #render" do
       template = Tilt::RDocTemplate.new { |t| "= Hello World!" }
-      assert_equal "<h1>Hello World!</h1>", template.render.strip
+      assert_equal "<h1 id=\"label-Hello+World%21\">Hello World!</h1>", template.render.strip
     end
 
     test "can be rendered more than once" do
       template = Tilt::RDocTemplate.new { |t| "= Hello World!" }
-      3.times { assert_equal "<h1>Hello World!</h1>", template.render.strip }
+      3.times { assert_equal "<h1 id=\"label-Hello+World%21\">Hello World!</h1>", template.render.strip }
     end
   end
 rescue LoadError => boom


### PR DESCRIPTION
The rdoc specs currently fail if rdoc >= 3.10 is installed, since the output changed a bit with that version. This version is around since 2011-10-08 . I guess this is enough time for everybody to upgrade.

Thanks!
