### PR TITLE
Fix to allow Tempfile based templates.

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -41,6 +41,7 @@ module Tilt
       [options, line, file].compact.each do |arg|
         case
         when arg.respond_to?(:to_str)  ; @file = arg.to_str
+        when arg.respond_to?(:path)    ; @file = arg.path
         when arg.respond_to?(:to_int)  ; @line = arg.to_int
         when arg.respond_to?(:to_hash) ; @options = arg.to_hash.dup
         else raise TypeError

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -1,5 +1,6 @@
 require 'contest'
 require 'tilt'
+require 'tempfile'
 
 class TiltTemplateTest < Test::Unit::TestCase
 
@@ -21,6 +22,12 @@ class TiltTemplateTest < Test::Unit::TestCase
     inst = MockTemplate.new('foo.erb', 55) {}
     assert_equal 'foo.erb', inst.file
     assert_equal 55, inst.line
+  end
+
+  test "initializing with a tempfile" do
+    tempfile = Tempfile.new('tilt_template_test')
+    inst = MockTemplate.new(tempfile)
+    assert_equal File.basename(tempfile.path), inst.basename
   end
 
   test "uses correct eval_file" do


### PR DESCRIPTION
Checks to see if the template file responds to #path, which Tempfile and File both respond to, so shouldn't be an issue.

Also, added a test in tilt_template_test.rb
