### PR TITLE
Add assert_not_match method for coffescript tests

### DIFF
--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -5,6 +5,17 @@ begin
   require 'coffee_script'
 
   class CoffeeScriptTemplateTest < Test::Unit::TestCase
+
+    unless method_defined?(:assert_not_match)
+      # assert_not_match is missing on 1.8.7, which uses assert_no_match
+      def assert_not_match(a, b)
+        unless a.kind_of?(Regexp)
+          a = Regexp.new(Regexp.escape(a))
+        end
+        assert_no_match(a,b)
+      end
+    end
+
     test "is registered for '.coffee' files" do
       assert_equal Tilt::CoffeeScriptTemplate, Tilt['test.coffee']
     end


### PR DESCRIPTION
Apparently 1.8.7 does not have the assert_not_match method (instead it has assert_no_match -- this was news to me).  Add it to the coffescript tests so they pass in both 1.8.7 and 1.9.2.
