### PR TITLE
Add allows_script? method to Template

### DIFF
--- a/lib/tilt/coffee.rb
+++ b/lib/tilt/coffee.rb
@@ -45,6 +45,10 @@ module Tilt
     def evaluate(scope, locals, &block)
       @output ||= CoffeeScript.compile(data, options)
     end
+
+    def allows_script?
+      false
+    end
   end
 end
 

--- a/lib/tilt/css.rb
+++ b/lib/tilt/css.rb
@@ -24,6 +24,10 @@ module Tilt
       @output ||= @engine.render
     end
 
+    def allows_script?
+      false
+    end
+
   private
     def sass_options
       options.merge(:filename => eval_file, :line => line, :syntax => :sass)
@@ -66,6 +70,10 @@ module Tilt
 
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_css
+    end
+
+    def allows_script?
+      false
     end
   end
 end

--- a/lib/tilt/liquid.rb
+++ b/lib/tilt/liquid.rb
@@ -37,5 +37,9 @@ module Tilt
       locals['content'] = locals['yield']
       @engine.render(locals)
     end
+
+    def allows_script?
+      false
+    end
   end
 end

--- a/lib/tilt/markdown.rb
+++ b/lib/tilt/markdown.rb
@@ -37,6 +37,10 @@ module Tilt
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_html
     end
+
+    def allows_script?
+      false
+    end
   end
 
   # Upskirt Markdown implementation. See:
@@ -59,6 +63,10 @@ module Tilt
 
     def evaluate(scope, locals, &block)
       @engine.evaluate(scope, locals, &block)
+    end
+
+    def allows_script?
+      false
     end
 
     # Compatibility mode for Redcarpet 1.x
@@ -116,6 +124,10 @@ module Tilt
       def evaluate(scope, locals, &block)
         @output ||= @engine.render(data)
       end
+
+      def allows_script?
+        false
+      end
     end
   end
 
@@ -140,6 +152,10 @@ module Tilt
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_html
     end
+
+    def allows_script?
+      false
+    end
   end
 
   # Maruku markdown implementation. See:
@@ -160,6 +176,10 @@ module Tilt
 
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_html
+    end
+
+    def allows_script?
+      false
     end
   end
 
@@ -184,6 +204,10 @@ module Tilt
 
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_html
+    end
+
+    def allows_script?
+      false
     end
   end
 end

--- a/lib/tilt/radius.rb
+++ b/lib/tilt/radius.rb
@@ -47,5 +47,9 @@ module Tilt
       parser = Radius::Parser.new(context, options)
       parser.parse(data)
     end
+
+    def allows_script?
+      false
+    end
   end
 end

--- a/lib/tilt/rdoc.rb
+++ b/lib/tilt/rdoc.rb
@@ -29,5 +29,9 @@ module Tilt
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_s
     end
+
+    def allows_script?
+      false
+    end
   end
 end

--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -92,6 +92,15 @@ module Tilt
       file || '(__TEMPLATE__)'
     end
 
+    # Whether or not this template engine allows executing Ruby script
+    # within the template. If this is false, +scope+ and +locals+ will
+    # generally not be used, nor will the provided block be avaiable 
+    # via +yield+.
+    # This should be overridden by template subclasses.
+    def allows_script?
+      true
+    end
+
   protected
     # Called once and only once for each template subclass the first time
     # the template class is initialized. This should be used to require the

--- a/lib/tilt/textile.rb
+++ b/lib/tilt/textile.rb
@@ -20,6 +20,10 @@ module Tilt
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_html
     end
+
+    def allows_script?
+      false
+    end
   end
 end
 

--- a/lib/tilt/wiki.rb
+++ b/lib/tilt/wiki.rb
@@ -24,6 +24,10 @@ module Tilt
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_html
     end
+
+    def allows_script?
+      false
+    end
   end
 
   # WikiCloth implementation. See:
@@ -45,6 +49,10 @@ module Tilt
 
     def evaluate(scope, locals, &block)
       @output ||= @engine.to_html
+    end
+
+    def allows_script?
+      false
     end
   end
 end


### PR DESCRIPTION
This change adds an `allows_script?` method to all `Template` classes that indicates whether that template engine allows running arbitrary Ruby script. This is useful for users of Tilt who want to disallow templates that support script or who want to treat them differently.

While I can see this being generally useful, I'm interested in it specifically because I'm trying to make a patch to Haml that makes it use Tilt for its other-template-engine filters, replacing the special-case filter handling it has now (see https://github.com/bhollis/haml/tree/tilt). The trick is that Haml has a setting to disallow arbitrary scripts, which means I would have to know whether a particular Tilt engine could execute script and handle it differently.
