### PR TITLE
Improve API compatibility with ERB templates

### DIFF
--- a/lib/tilt/erb.rb
+++ b/lib/tilt/erb.rb
@@ -24,7 +24,7 @@ module Tilt
 
     def prepare
       @outvar = options[:outvar] || self.class.default_output_variable
-      options[:trim] = '<>' if options[:trim].nil? || options[:trim] == true
+      options[:trim] = '<>' if !(options[:trim] == false) && (options[:trim].nil? || options[:trim] == true)
       @engine = ::ERB.new(data, options[:safe], options[:trim], @outvar)
     end
 

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -89,6 +89,11 @@ class ERBTemplateTest < Test::Unit::TestCase
     end
   end
 
+  test "explicit disabling of trim mode" do
+    template = Tilt::ERBTemplate.new('test.erb', 1, :trim => false) { "\n<%= 1 + 1 %>\n" }
+    assert_equal "\n2\n", template.render
+  end
+
   test "default stripping trim mode" do
     template = Tilt::ERBTemplate.new('test.erb', 1) { "\n<%= 1 + 1 %>\n" }
     assert_equal "\n2", template.render


### PR DESCRIPTION
The current API for `Tilt::ERBTemplate` makes it impossible to disable trim mode in `ERB::Compiler`. Disabling trim mode is important in cases where ERB is used to generate something other than HTML. 

Adding an explicit `trim: false` option to `Tilt::ERBTemplate` improves API compatibility with ERB while maintaining backward compatibility.
