### PR TITLE
Added Option support for RedCloth template

### DIFF
--- a/lib/tilt/textile.rb
+++ b/lib/tilt/textile.rb
@@ -14,6 +14,7 @@ module Tilt
 
     def prepare
       @engine = RedCloth.new(data)
+      options.each {|k, v| @engine.send("#{k}=", v)}
       @output = nil
     end
 

--- a/test/tilt_redclothtemplate_test.rb
+++ b/test/tilt_redclothtemplate_test.rb
@@ -18,6 +18,13 @@ begin
       template = Tilt::RedClothTemplate.new { |t| "h1. Hello World!" }
       3.times { assert_equal "<h1>Hello World!</h1>", template.render }
     end
+
+    test "passes in RedCloth options" do
+      template = Tilt::RedClothTemplate.new { |t| "Hard breaks are\ninserted by default." }
+      assert_equal "<p>Hard breaks are<br />\ninserted by default.</p>", template.render
+      template = Tilt::RedClothTemplate.new(:hard_breaks => false) { |t| "But they can be\nturned off." }
+      assert_equal "<p>But they can be\nturned off.</p>", template.render
+    end
   end
 rescue LoadError => boom
   warn "Tilt::RedClothTemplate (disabled)"


### PR DESCRIPTION
Now RedCloth options like :hard_breaks or :no_span_caps can be passed through Tilt.  I needed this when using Slim.

-Matt
