### PR TITLE
Restrict locals to valid variable names

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -186,7 +186,13 @@ module Tilt
     # source line offset, so adding code to the preamble does not effect line
     # reporting in Kernel::caller and backtraces.
     def precompiled_preamble(locals)
-      locals.map { |k,v| k.to_s =~ /\A[a-z]\w*\z/ ? "#{k} = locals[#{k.inspect}]" : nil }.join("\n")
+      locals.map do |k,v|
+        if k.to_s =~ /\A[a-z]\w*\z/
+          "#{k} = locals[#{k.inspect}]"
+        else
+          raise "invalid locals key: #{k.inspect} (keys must be variable names)"
+        end
+      end.join("\n")
     end
 
     # Generates postamble code for the precompiled template source. The

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -134,10 +134,10 @@ class TiltTemplateTest < Test::Unit::TestCase
     assert inst.prepared?
   end
 
-  test "template_source with locals of invalid variable names" do
-    inst = SourceGeneratingMockTemplate.new { |t| '1 + 2 = #{Math::PI.to_i}' }
-    assert_equal "1 + 2 = 3", inst.render(Object.new, 'Math::PI' => '42')
-    assert inst.prepared?
+  test "template_source with locals having non-variable keys raises error" do
+    inst = SourceGeneratingMockTemplate.new { |t| '1 + 2 = #{ANSWER}' }
+    err = assert_raise(RuntimeError) { inst.render(Object.new, 'ANSWER' => '3') }
+    assert_equal "invalid locals key: \"ANSWER\" (keys must be variable names)", err.message
   end
 
   class Person


### PR DESCRIPTION
Local keys are evaluated as ruby meaning all kinds of shenanigans are possible unless the keys are filtered.  Restricting them to variable names seems safe and reasonable.

I ran across this when accidentally passing something like `A/B` as a key, which failed trying to divide missing constants.
