### PR TITLE
Autoload lib/tilt/*.rb

### DIFF
--- a/test/tilt_blueclothtemplate_test.rb
+++ b/test/tilt_blueclothtemplate_test.rb
@@ -6,15 +6,15 @@ begin
 
   class BlueClothTemplateTest < Test::Unit::TestCase
     test "registered for '.md' files" do
-      assert Tilt.mappings['md'].include?(Tilt::BlueClothTemplate)
+      assert Tilt.mappings['md'].include?(:BlueClothTemplate)
     end
 
     test "registered for '.mkd' files" do
-      assert Tilt.mappings['mkd'].include?(Tilt::BlueClothTemplate)
+      assert Tilt.mappings['mkd'].include?(:BlueClothTemplate)
     end
 
     test "registered for '.markdown' files" do
-      assert Tilt.mappings['markdown'].include?(Tilt::BlueClothTemplate)
+      assert Tilt.mappings['markdown'].include?(:BlueClothTemplate)
     end
 
     test "preparing and evaluating templates on #render" do

--- a/test/tilt_creoletemplate_test.rb
+++ b/test/tilt_creoletemplate_test.rb
@@ -10,7 +10,7 @@ begin
     end
 
     test "registered for '.wiki' files" do
-      assert Tilt.mappings['wiki'].include?(Tilt::CreoleTemplate)
+      assert Tilt.mappings['wiki'].include?(:CreoleTemplate)
     end
 
     test "compiles and evaluates the template on #render" do

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -6,11 +6,11 @@ require 'tempfile'
 
 class ERBTemplateTest < Test::Unit::TestCase
   test "registered for '.erb' files" do
-    assert Tilt.mappings['erb'].include?(Tilt::ERBTemplate)
+    assert Tilt.mappings['erb'].include?(:ERBTemplate)
   end
 
   test "registered for '.rhtml' files" do
-    assert Tilt.mappings['rhtml'].include?(Tilt::ERBTemplate)
+    assert Tilt.mappings['rhtml'].include?(:ERBTemplate)
   end
 
   test "loading and evaluating templates on #render" do

--- a/test/tilt_erubistemplate_test.rb
+++ b/test/tilt_erubistemplate_test.rb
@@ -12,8 +12,8 @@ begin
     test "registered above ERB" do
       %w[erb rhtml].each do |ext|
         mappings = Tilt.mappings[ext]
-        erubis_idx = mappings.index(Tilt::ErubisTemplate)
-        erb_idx = mappings.index(Tilt::ERBTemplate)
+        erubis_idx = mappings.index(:ErubisTemplate)
+        erb_idx = mappings.index(:ERBTemplate)
         assert erubis_idx < erb_idx,
           "#{erubis_idx} should be lower than #{erb_idx}"
       end

--- a/test/tilt_fallback_test.rb
+++ b/test/tilt_fallback_test.rb
@@ -2,7 +2,7 @@ require 'contest'
 require 'tilt'
 
 class TiltFallbackTest < Test::Unit::TestCase
-  class FailTemplate  < Tilt::Template
+  class Tilt::FailTemplate  < Tilt::Template
     def self.engine_initialized?; false end
     def prepare;                        end
 
@@ -11,13 +11,13 @@ class TiltFallbackTest < Test::Unit::TestCase
     end
   end
 
-  class WinTemplate < Tilt::Template
+  class Tilt::WinTemplate < Tilt::Template
     def self.engine_initialized?; true end
     def prepare;                       end
   end
 
-  FailTemplate2 = Class.new(FailTemplate)
-  WinTemplate2  = Class.new(WinTemplate)
+  class Tilt::FailTemplate2 < Tilt::FailTemplate; end
+  class Tilt::WinTemplate2  < Tilt::WinTemplate;  end
 
   def set_ivar(obj, name, value)
     obj.instance_variable_set("@#{name}", value)
@@ -47,50 +47,50 @@ class TiltFallbackTest < Test::Unit::TestCase
   end
 
   test "returns the last registered template" do
-    Tilt.register("md", WinTemplate)
-    Tilt.register("md", WinTemplate2)
+    Tilt.register("md", Tilt::WinTemplate)
+    Tilt.register("md", Tilt::WinTemplate2)
 
     template = Tilt["md"]
-    assert_equal WinTemplate2, template
+    assert_equal Tilt::WinTemplate2, template
   end
 
   test "returns the last registered working template" do
-    Tilt.register("md", WinTemplate)
-    Tilt.register("md", FailTemplate)
+    Tilt.register("md", Tilt::WinTemplate)
+    Tilt.register("md", Tilt::FailTemplate)
 
     template = Tilt["md"]
-    assert_equal WinTemplate, template
+    assert_equal Tilt::WinTemplate, template
   end
 
   test "if every template fails, raise the exception from the first template" do
-    Tilt.register("md", FailTemplate)
-    Tilt.register("md", FailTemplate2)
+    Tilt.register("md", Tilt::FailTemplate)
+    Tilt.register("md", Tilt::FailTemplate2)
 
     exc = assert_raise(LoadError) { Tilt["md"] }
     assert_match /FailTemplate2/, exc.message
   end
 
   test ".prefer should also register the template" do
-    Tilt.prefer(WinTemplate, "md")
+    Tilt.prefer(Tilt::WinTemplate, "md")
     assert Tilt.registered?("md")
   end
 
   test ".prefer always win" do
-    Tilt.register("md", FailTemplate)
-    Tilt.register("md", WinTemplate)
-    Tilt.prefer(FailTemplate, "md")
+    Tilt.register("md", Tilt::FailTemplate)
+    Tilt.register("md", Tilt::WinTemplate)
+    Tilt.prefer(Tilt::FailTemplate, "md")
 
     template = Tilt["md"]
-    assert_equal FailTemplate, template
+    assert_equal Tilt::FailTemplate, template
   end
 
   test ".prefer accepts multiple extensions" do
     extensions = %w[md mkd markdown]
-    Tilt.prefer(FailTemplate, *extensions)
+    Tilt.prefer(Tilt::FailTemplate, *extensions)
 
     extensions.each do |ext|
       template = Tilt[ext]
-      assert_equal FailTemplate, template
+      assert_equal Tilt::FailTemplate, template
     end
   end
 
@@ -98,25 +98,25 @@ class TiltFallbackTest < Test::Unit::TestCase
     extensions = %w[md mkd markdown]
 
     extensions.each do |ext|
-      Tilt.register(ext, FailTemplate)
-      Tilt.register(ext, WinTemplate)
+      Tilt.register(ext, Tilt::FailTemplate)
+      Tilt.register(ext, Tilt::WinTemplate)
     end
 
-    Tilt.prefer(FailTemplate)
+    Tilt.prefer(Tilt::FailTemplate)
 
     extensions.each do |ext|
       template = Tilt[ext]
-      assert_equal FailTemplate, template
+      assert_equal Tilt::FailTemplate, template
     end
   end
 
   test ".prefer should only override extensions the preferred library is registered for"  do
-    Tilt.register("md", WinTemplate)
-    Tilt.register("mkd", FailTemplate)
-    Tilt.register("mkd", WinTemplate)
-    Tilt.prefer(FailTemplate)
-    assert_equal FailTemplate, Tilt["mkd"]
-    assert_equal WinTemplate, Tilt["md"]
+    Tilt.register("md", Tilt::WinTemplate)
+    Tilt.register("mkd", Tilt::FailTemplate)
+    Tilt.register("mkd", Tilt::WinTemplate)
+    Tilt.prefer(Tilt::FailTemplate)
+    assert_equal Tilt::FailTemplate, Tilt["mkd"]
+    assert_equal Tilt::WinTemplate, Tilt["md"]
   end
 end
 

--- a/test/tilt_kramdown_test.rb
+++ b/test/tilt_kramdown_test.rb
@@ -6,22 +6,22 @@ begin
 
   class MarukuTemplateTest < Test::Unit::TestCase
     test "registered for '.md' files" do
-      assert Tilt.mappings['md'].include?(Tilt::KramdownTemplate)
+      assert Tilt.mappings['md'].include?(:KramdownTemplate)
     end
 
     test "registered for '.mkd' files" do
-      assert Tilt.mappings['mkd'].include?(Tilt::KramdownTemplate)
+      assert Tilt.mappings['mkd'].include?(:KramdownTemplate)
     end
 
     test "registered for '.markdown' files" do
-      assert Tilt.mappings['markdown'].include?(Tilt::KramdownTemplate)
+      assert Tilt.mappings['markdown'].include?(:KramdownTemplate)
     end
 
     test "registered above MarukuTemplate" do
       %w[md mkd markdown].each do |ext|
         mappings = Tilt.mappings[ext]
-        kram_idx = mappings.index(Tilt::KramdownTemplate)
-        maru_idx = mappings.index(Tilt::MarukuTemplate)
+        kram_idx = mappings.index(:KramdownTemplate)
+        maru_idx = mappings.index(:MarukuTemplate)
         assert kram_idx < maru_idx,
           "#{kram_idx} should be lower than #{maru_idx}"
       end

--- a/test/tilt_lesstemplate_test.less
+++ b/test/tilt_lesstemplate_test.less
@@ -1,1 +1,1 @@
-@text-color: pink;
+@text-color: #ffc0cb;

--- a/test/tilt_lesstemplate_test.rb
+++ b/test/tilt_lesstemplate_test.rb
@@ -29,7 +29,7 @@ begin
         .bg {background-color: @text-color;}
         EOLESS
       }
-      assert_equal ".bg {\n  background-color: pink;\n}\n", template.render
+      assert_equal ".bg {\n  background-color: #ffc0cb;\n}\n", template.render
     end
   end
 

--- a/test/tilt_marukutemplate_test.rb
+++ b/test/tilt_marukutemplate_test.rb
@@ -6,22 +6,22 @@ begin
 
   class MarukuTemplateTest < Test::Unit::TestCase
     test "registered for '.md' files" do
-      assert Tilt.mappings['md'].include?(Tilt::MarukuTemplate)
+      assert Tilt.mappings['md'].include?(:MarukuTemplate)
     end
 
     test "registered for '.mkd' files" do
-      assert Tilt.mappings['mkd'].include?(Tilt::MarukuTemplate)
+      assert Tilt.mappings['mkd'].include?(:MarukuTemplate)
     end
 
     test "registered for '.markdown' files" do
-      assert Tilt.mappings['markdown'].include?(Tilt::MarukuTemplate)
+      assert Tilt.mappings['markdown'].include?(:MarukuTemplate)
     end
 
     test "registered below Kramdown" do
       %w[md mkd markdown].each do |ext|
         mappings = Tilt.mappings[ext]
-        kram_idx = mappings.index(Tilt::KramdownTemplate)
-        maru_idx = mappings.index(Tilt::MarukuTemplate)
+        kram_idx = mappings.index(:KramdownTemplate)
+        maru_idx = mappings.index(:MarukuTemplate)
         assert maru_idx > kram_idx,
           "#{maru_idx} should be higher than #{kram_idx}"
       end

--- a/test/tilt_rdiscounttemplate_test.rb
+++ b/test/tilt_rdiscounttemplate_test.rb
@@ -6,22 +6,22 @@ begin
 
   class RDiscountTemplateTest < Test::Unit::TestCase
     test "registered for '.md' files" do
-      assert Tilt.mappings['md'].include?(Tilt::RDiscountTemplate)
+      assert Tilt.mappings['md'].include?(:RDiscountTemplate)
     end
 
     test "registered for '.mkd' files" do
-      assert Tilt.mappings['mkd'].include?(Tilt::RDiscountTemplate)
+      assert Tilt.mappings['mkd'].include?(:RDiscountTemplate)
     end
 
     test "registered for '.markdown' files" do
-      assert Tilt.mappings['markdown'].include?(Tilt::RDiscountTemplate)
+      assert Tilt.mappings['markdown'].include?(:RDiscountTemplate)
     end
 
     test "registered above BlueCloth" do
       %w[md mkd markdown].each do |ext|
         mappings = Tilt.mappings[ext]
-        blue_idx = mappings.index(Tilt::BlueClothTemplate)
-        rdis_idx = mappings.index(Tilt::RDiscountTemplate)
+        blue_idx = mappings.index(:BlueClothTemplate)
+        rdis_idx = mappings.index(:RDiscountTemplate)
         assert rdis_idx < blue_idx,
           "#{rdis_idx} should be lower than #{blue_idx}"
       end

--- a/test/tilt_rdoctemplate_test.rb
+++ b/test/tilt_rdoctemplate_test.rb
@@ -12,12 +12,12 @@ begin
 
     test "preparing and evaluating the template with #render" do
       template = Tilt::RDocTemplate.new { |t| "= Hello World!" }
-      assert_equal "<h1 id=\"label-Hello+World%21\">Hello World!</h1>", template.render.strip
+      assert_equal "<h1>Hello World!</h1>", template.render.strip
     end
 
     test "can be rendered more than once" do
       template = Tilt::RDocTemplate.new { |t| "= Hello World!" }
-      3.times { assert_equal "<h1 id=\"label-Hello+World%21\">Hello World!</h1>", template.render.strip }
+      3.times { assert_equal "<h1>Hello World!</h1>", template.render.strip }
     end
   end
 rescue LoadError => boom

--- a/test/tilt_redcarpettemplate_test.rb
+++ b/test/tilt_redcarpettemplate_test.rb
@@ -6,22 +6,22 @@ begin
 
   class RedcarpetTemplateTest < Test::Unit::TestCase
     test "registered for '.md' files" do
-      assert Tilt.mappings['md'].include?(Tilt::RedcarpetTemplate)
+      assert Tilt.mappings['md'].include?(:RedcarpetTemplate)
     end
 
     test "registered for '.mkd' files" do
-      assert Tilt.mappings['mkd'].include?(Tilt::RedcarpetTemplate)
+      assert Tilt.mappings['mkd'].include?(:RedcarpetTemplate)
     end
 
     test "registered for '.markdown' files" do
-      assert Tilt.mappings['markdown'].include?(Tilt::RedcarpetTemplate)
+      assert Tilt.mappings['markdown'].include?(:RedcarpetTemplate)
     end
 
     test "registered above BlueCloth" do
       %w[md mkd markdown].each do |ext|
         mappings = Tilt.mappings[ext]
-        blue_idx = mappings.index(Tilt::BlueClothTemplate)
-        redc_idx = mappings.index(Tilt::RedcarpetTemplate)
+        blue_idx = mappings.index(:BlueClothTemplate)
+        redc_idx = mappings.index(:RedcarpetTemplate)
         assert redc_idx < blue_idx,
           "#{redc_idx} should be lower than #{blue_idx}"
       end
@@ -30,8 +30,8 @@ begin
     test "registered above RDiscount" do
       %w[md mkd markdown].each do |ext|
         mappings = Tilt.mappings[ext]
-        rdis_idx = mappings.index(Tilt::RDiscountTemplate)
-        redc_idx = mappings.index(Tilt::RedcarpetTemplate)
+        rdis_idx = mappings.index(:RDiscountTemplate)
+        redc_idx = mappings.index(:RedcarpetTemplate)
         assert redc_idx < rdis_idx,
           "#{redc_idx} should be lower than #{rdis_idx}"
       end

--- a/test/tilt_test.rb
+++ b/test/tilt_test.rb
@@ -1,7 +1,7 @@
 require 'contest'
 require 'tilt'
 
-class TiltTest < Test::Unit::TestCase
+module Tilt
   class MockTemplate
     attr_reader :args, :block
     def initialize(*args, &block)
@@ -9,42 +9,45 @@ class TiltTest < Test::Unit::TestCase
       @block = block
     end
   end
+end
+
+class TiltTest < Test::Unit::TestCase
 
   test "registering template implementation classes by file extension" do
-    Tilt.register('mock', MockTemplate)
+    Tilt.register('mock', Tilt::MockTemplate)
   end
 
   test "an extension is registered if explicit handle is found" do
-    Tilt.register('mock', MockTemplate)
+    Tilt.register('mock', Tilt::MockTemplate)
     assert Tilt.registered?('mock')
   end
 
   test "registering template classes by symbol file extension" do
-    Tilt.register(:mock, MockTemplate)
+    Tilt.register(:mock, Tilt::MockTemplate)
   end
 
   test "looking up template classes by exact file extension" do
-    Tilt.register('mock', MockTemplate)
+    Tilt.register('mock', Tilt::MockTemplate)
     impl = Tilt['mock']
-    assert_equal MockTemplate, impl
+    assert_equal Tilt::MockTemplate, impl
   end
 
   test "looking up template classes by implicit file extension" do
-    Tilt.register('mock', MockTemplate)
+    Tilt.register('mock', Tilt::MockTemplate)
     impl = Tilt['.mock']
-    assert_equal MockTemplate, impl
+    assert_equal Tilt::MockTemplate, impl
   end
 
   test "looking up template classes with multiple file extensions" do
-    Tilt.register('mock', MockTemplate)
+    Tilt.register('mock', Tilt::MockTemplate)
     impl = Tilt['index.html.mock']
-    assert_equal MockTemplate, impl
+    assert_equal Tilt::MockTemplate, impl
   end
 
   test "looking up template classes by file name" do
-    Tilt.register('mock', MockTemplate)
+    Tilt.register('mock', Tilt::MockTemplate)
     impl = Tilt['templates/test.mock']
-    assert_equal MockTemplate, impl
+    assert_equal Tilt::MockTemplate, impl
   end
 
   test "looking up non-existant template class" do
@@ -57,7 +60,7 @@ class TiltTest < Test::Unit::TestCase
   end
 
   test "creating new template instance with a filename" do
-    Tilt.register('mock', MockTemplate)
+    Tilt.register('mock', Tilt::MockTemplate)
     template = Tilt.new('foo.mock', 1, :key => 'val') { 'Hello World!' }
     assert_equal ['foo.mock', 1, {:key => 'val'}], template.args
     assert_equal 'Hello World!', template.block.call


### PR DESCRIPTION
Tilt is requiring a lot of engine classes even if they're not used. As a result memory footprint is excess around 2 MB and load time of app is excess 0.3s.

Implementing ruby true autoload feature solves the problem.
