### PR TITLE
Allow output options such as {:compress => true} to be used with LESS

### DIFF
--- a/lib/tilt/css.rb
+++ b/lib/tilt/css.rb
@@ -69,7 +69,7 @@ module Tilt
     end
 
     def evaluate(scope, locals, &block)
-      @output ||= @engine.to_css (options)
+      @output ||= @engine.to_css(options)
     end
 
     def allows_script?


### PR DESCRIPTION
Allow output options such as {:compress => true} to be used with LESS templates (this option can only be passed to .to_css(), it is ignored by Parser::new(), as they are separate classes.
