### PR TITLE
Add Org-mode to engines with Tilt integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These template engines ship with their own Tilt integration:
     Embedded JavaScript                          sprockets
     Embedded CoffeeScript                        sprockets
     JST                                          sprockets
+    Org-mode                   .org              org-ruby (>= 0.6.2)
 
 See [TEMPLATES.md][t] for detailed information on template engine
 options and supported features.


### PR DESCRIPTION
Update README to include org-ruby Org-Mode Tilt support
