### PR TITLE
add license information to the gemspec

### DIFF
--- a/tilt.gemspec
+++ b/tilt.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
 
   s.description = "Generic interface to multiple Ruby template engines"
   s.summary     = s.description
+  s.license     = "MIT"
 
   s.authors = ["Ryan Tomayko"]
   s.email = "r@tomayko.com"


### PR DESCRIPTION
this way it can be used with rubygems.org
