### PR TITLE
Add support for @ and _ as prefix to locals variable

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -187,7 +187,7 @@ module Tilt
     # reporting in Kernel::caller and backtraces.
     def precompiled_preamble(locals)
       locals.map do |k,v|
-        if k.to_s =~ /\A[a-z]\w*\z/
+        if k.to_s =~ /\A(@|_)?[a-z]\w*\z/
           "#{k} = locals[#{k.inspect}]"
         else
           raise "invalid locals key: #{k.inspect} (keys must be variable names)"


### PR DESCRIPTION
With the commit: https://github.com/rtomayko/tilt/commit/d4c67207dbc02aced72b13ddd1b1f0e8b08b2526 and the consequent version bump, we issues a problem with our code because we are using as locals the @ before a variable name and sometimes also the underscore. While until 1.3.3 it was working flawlessly now we hit the wall.

The issue is actually fixable just slightly modifying the regex with: \A(@|_)?[a-z]\w*\z 

This patch fix the issue
