### PR TITLE
Change extension for CSV templates to 'rcsv'

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Support for these template engines is included with the package:
     Creole (Wiki markup)       .wiki, .creole          creole
     WikiCloth (Wiki markup)    .wiki, .mediawiki, .mw  wikicloth
     Yajl                       .yajl                   yajl-ruby
-    CSV                        .csv                    none (Ruby >= 1.9), fastercsv (Ruby < 1.9)
+    CSV                        .rcsv                   none (Ruby >= 1.9), fastercsv (Ruby < 1.9)
 
 These template engines ship with their own Tilt integration:
 

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -154,7 +154,7 @@ module Tilt
   register LessTemplate, 'less'
 
   require 'tilt/csv'
-  register CSVTemplate, 'csv'
+  register CSVTemplate, 'rcsv'
 
   require 'tilt/coffee'
   register CoffeeScriptTemplate, 'coffee'

--- a/test/tilt_csv_test.rb
+++ b/test/tilt_csv_test.rb
@@ -10,12 +10,8 @@ begin
 
   class CSVTemplateTest < Test::Unit::TestCase
 
-    test "is registered for '.csv' files" do
-      assert_equal Tilt::CSVTemplate, Tilt['test.csv']
-    end
-
-    test "registered for '.csv' files" do
-      assert Tilt.mappings['csv'].include?(Tilt::CSVTemplate)
+    test "registered for '.rcsv' files" do
+      assert Tilt.mappings['rcsv'].include?(Tilt::CSVTemplate)
     end
 
     test "compiles and evaluates the template on #render" do


### PR DESCRIPTION
I wonder if it might be sensible to change the file extension for CSV templates (issue #153) to '.rcsv' to disambiguate from common 'csv' files.
