### PR TITLE
Check for ::Erubis::Eruby in Erubis template

### DIFF
--- a/lib/tilt/erb.rb
+++ b/lib/tilt/erb.rb
@@ -74,7 +74,7 @@ module Tilt
   #                   within <%= %> blocks will be automatically html escaped.
   class ErubisTemplate < ERBTemplate
     def self.engine_initialized?
-      defined? ::Erubis
+      defined? ::Erubis::Eruby
     end
 
     def initialize_engine


### PR DESCRIPTION
If the Erubis module had been defined but not the Eruby class (which
can happen if you require erubis/tiny) the Erubis template fails with an
"uninitialized constant" error.

Check for the specific Eruby class rather than just the containing
module in `engine_initialised?`
