### PR TITLE
calling Tilt[] with unregistered file type shouldn't add empty mapping

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -73,6 +73,8 @@ module Tilt
       pattern.sub!(/^[^.]*\.?/, '')
     end
 
+    return nil if pattern.empty?
+
     # Try to find a preferred engine.
     preferred_klass = @preferred_mappings[pattern]
     return preferred_klass if preferred_klass

--- a/test/tilt_test.rb
+++ b/test/tilt_test.rb
@@ -48,7 +48,10 @@ class TiltTest < Test::Unit::TestCase
   end
 
   test "looking up non-existant template class" do
-    assert_nil Tilt['none']
+    length = Tilt.mappings.length
+    assert_nil Tilt['hello.world']
+    assert !Tilt.mappings.has_key?("")
+    assert_equal length, Tilt.mappings.length
   end
 
   test "accessing template class mappings at Tilt::mappings" do


### PR DESCRIPTION
If you call `Tilt[]` with an unregistered file type, it correctly returns `nil`, but also unexpectedly adds a mapping for `"" => []`. This happens because an empty string is passed to `Tilt.template_mappings[]`, and it creates a default value for that key of `[]`.

This pull request fixes that bug and includes a test case.
