### PR TITLE
Add ability to override the Builder XML indent amount

### DIFF
--- a/lib/tilt/builder.rb
+++ b/lib/tilt/builder.rb
@@ -11,14 +11,14 @@ module Tilt
 
     def evaluate(scope, locals, &block)
       return super(scope, locals, &block) if data.respond_to?(:to_str)
-      xml = ::Builder::XmlMarkup.new(:indent => 2)
+      xml = ::Builder::XmlMarkup.new(:indent => indent_amount)
       data.call(xml)
       xml.target!
     end
 
     def precompiled_preamble(locals)
       return super if locals.include? :xml
-      "xml = ::Builder::XmlMarkup.new(:indent => 2)\n#{super}"
+      "xml = ::Builder::XmlMarkup.new(:indent => #{indent_amount})\n#{super}"
     end
 
     def precompiled_postamble(locals)
@@ -28,6 +28,13 @@ module Tilt
     def precompiled_template(locals)
       data.to_str
     end
+
+    private
+
+    def indent_amount
+      options[:indent] || 2
+    end
+
   end
 end
 


### PR DESCRIPTION
Hello,

this change allows to pass the `:indent` option to to Builder.

It also works well inside @Sinatra, as `set :builder, :indent => 0` will pass that options hash to Tilt that will pass it along to Builder.

In the [1.3.7-indent branch](https://github.com/ifad/tilt/tree/1.3.7-indent) there's also a cherry-pick to `1.3.7`.

Thanks,

~Marcello
