### PR TITLE
Fix MarukuTemplate test.

### DIFF
--- a/test/tilt_marukutemplate_test.rb
+++ b/test/tilt_marukutemplate_test.rb
@@ -17,18 +17,18 @@ begin
 
     test "preparing and evaluating templates on #render" do
       template = Tilt::MarukuTemplate.new { |t| "# Hello World!" }
-      assert_equal "<h1 id='hello_world'>Hello World!</h1>", template.render
+      assert_equal "\n<h1 id=\"hello_world\">Hello World!</h1>\n", template.render
     end
 
     test "can be rendered more than once" do
       template = Tilt::MarukuTemplate.new { |t| "# Hello World!" }
-      3.times { assert_equal "<h1 id='hello_world'>Hello World!</h1>", template.render }
+      3.times { assert_equal "\n<h1 id=\"hello_world\">Hello World!</h1>\n", template.render }
     end
 
     test "removes HTML when :filter_html is set" do
       template = Tilt::MarukuTemplate.new(:filter_html => true) { |t|
         "HELLO <blink>WORLD</blink>" }
-      assert_equal "<p>HELLO </p>", template.render
+      assert_equal "\n<p>HELLO </p>\n", template.render
     end
   end
 rescue LoadError => boom


### PR DESCRIPTION
I've fixed the tests for the Maruku template.
NOTE: Now, Maruku prepends & appends newlines to HTML fragments (please, refer to the Maruku source code for details).
