### PR TITLE
Fix circular require warning when requiring 'tilt'

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -1,5 +1,4 @@
 require 'tilt/mapping'
-require 'tilt/template'
 
 # Namespace for Tilt. This module is not intended to be included anywhere.
 module Tilt


### PR DESCRIPTION
A simple `require 'tilt'` results in the following warning (when Ruby warnings are enabled):

> warning: loading in progress, circular require considered harmful

```
☽ ruby -w -r tilt -e exit
~/.gem/ruby/2.0.0/gems/tilt-2.0.0/lib/tilt/mapping.rb:151: warning: assigned but unused variable - prefix
~/.rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55: warning: loading in progress, circular require considered harmful - ~/.gem/ruby/2.0.0/gems/tilt-2.0.0/lib/tilt.rb
    from ~/.rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:144:in `require'
    from ~/.rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
    from ~/.rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:135:in `require'
    from ~/.gem/ruby/2.0.0/gems/tilt-2.0.0/lib/tilt.rb:2:in `<top (required)>'
    from ~/.rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from ~/.rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from ~/.gem/ruby/2.0.0/gems/tilt-2.0.0/lib/tilt/template.rb:1:in `<top (required)>'
    from ~/.rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from ~/.rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```

Since `tilt.rb` doesn’t actually need `Tilt::Template`, removing that require has no apparent negative effect and remedies the circular require issue.
