### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/tilt/mapping.rb
+++ b/lib/tilt/mapping.rb
@@ -148,7 +148,7 @@ module Tilt
     #
     # @return [template class]
     def [](file)
-      prefix, ext = split(file)
+      _, ext = split(file)
       ext && lookup(ext)
     end
 


### PR DESCRIPTION
This fixes the following warning that occurs when requiring Tilt:

> warning: assigned but unused variable - prefix
