### PR TITLE
Update "upcoming release" of tilt in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Tilt [![Build Status](https://secure.travis-ci.org/rtomayko/tilt.png)](http://travis-ci.org/rtomayko/tilt) [![Dependency Status](https://gemnasium.com/rtomayko/tilt.png)](https://gemnasium.com/rtomayko/tilt)
 ====
 
-**NOTE** The following file documents the upcoming release of Tilt (2.1). See
-https://github.com/rtomayko/tilt/tree/v2.0.0 for the current version.
+**NOTE** The following file documents the current release of Tilt (2.0). See
+https://github.com/rtomayko/tilt/tree/tilt-1 for documentation for Tilt 1.4.
 
 Tilt is a thin interface over a bunch of different Ruby template engines in
 an attempt to make their usage as generic as possible. This is useful for web


### PR DESCRIPTION
Version 2.0 of Tilt is apparently out, so the README shouldn't state that v2.0 is still upcoming.
