### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Tilt [![Build Status](https://secure.travis-ci.org/rtomayko/tilt.png)](http://travis-ci.org/rtomayko/tilt) [![Dependency Status](https://gemnasium.com/rtomayko/tilt.png)](https://gemnasium.com/rtomayko/tilt)
+Tilt [![Build Status](https://secure.travis-ci.org/rtomayko/tilt.png)](http://travis-ci.org/rtomayko/tilt) [![Dependency Status](https://gemnasium.com/rtomayko/tilt.png)](https://gemnasium.com/rtomayko/tilt) [![Inline docs](http://inch-pages.github.io/github/rtomayko/tilt.png)](http://inch-pages.github.io/github/rtomayko/tilt)
 ====
 
 **NOTE** The following file documents the current release of Tilt (2.0). See

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Tilt [![Build Status](https://secure.travis-ci.org/rtomayko/tilt.png)](http://travis-ci.org/rtomayko/tilt) [![Dependency Status](https://gemnasium.com/rtomayko/tilt.png)](https://gemnasium.com/rtomayko/tilt) [![Inline docs](http://inch-pages.github.io/github/rtomayko/tilt.png)](http://inch-pages.github.io/github/rtomayko/tilt)
+Tilt [![Build Status](https://secure.travis-ci.org/rtomayko/tilt.png)](http://travis-ci.org/rtomayko/tilt) [![Dependency Status](https://gemnasium.com/rtomayko/tilt.png)](https://gemnasium.com/rtomayko/tilt) [![Inline docs](http://inch-ci.org/github/rtomayko/tilt.png)](http://inch-ci.org/github/rtomayko/tilt)
 ====
 
 **NOTE** The following file documents the current release of Tilt (2.0). See


### PR DESCRIPTION
Hi Ryan,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/rtomayko/tilt.png)](http://inch-pages.github.io/github/rtomayko/tilt)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Tilt is http://inch-pages.github.io/github/rtomayko/tilt/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
