### PR TITLE
Prefer ERb over Erubis as default engine for .erb files

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -98,8 +98,8 @@ module Tilt
   # Template Implementations ================================================
 
   # ERB
-  register_lazy :ERBTemplate,    'tilt/erb',    'erb', 'rhtml'
   register_lazy :ErubisTemplate, 'tilt/erubis', 'erb', 'rhtml', 'erubis'
+  register_lazy :ERBTemplate,    'tilt/erb',    'erb', 'rhtml'
 
   # Markdown
   register_lazy :BlueClothTemplate,  'tilt/bluecloth', 'markdown', 'mkd', 'md'

--- a/test/tilt_erubistemplate_test.rb
+++ b/test/tilt_erubistemplate_test.rb
@@ -14,7 +14,7 @@ begin
         lazy = Tilt.lazy_map[ext]
         erubis_idx = lazy.index { |klass, file| klass == 'Tilt::ErubisTemplate' }
         erb_idx = lazy.index { |klass, file| klass == 'Tilt::ERBTemplate' }
-        assert erubis_idx < erb_idx,
+        assert erubis_idx > erb_idx,
           "#{erubis_idx} should be lower than #{erb_idx}"
       end
     end


### PR DESCRIPTION
Erubis is the preferred choice of Tilt.
Actually, if a library built on top of Tilt wants to reuse the default mapping, is forced to have it as dependency.

To be clear, I don't have nothing against Erubis, but it's an external dependency, and in general, reduce dependencies is always good for end developers. Let them to opt-in for it, if they prefer.
