### PR TITLE
Add jbuilder template support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Add Jbuilder template support (#239, joshwlewis)
+
 ## 2.0.1 (2014-03-21)
 
 * Fix Tilt::Mapping bug in Ruby 2.1.0 (9589652c569760298f2647f7a0f9ed4f85129f20)

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :engines do
   gem 'creole'
   gem 'erubis'
   gem 'haml', '>= 2.2.11', '< 4'
+  gem 'jbuilder' if RUBY_VERSION > '1.9.2'
   gem 'kramdown'
   gem 'less'
   gem 'liquid'

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Support for these template engines is included with the package:
 | WikiCloth (Wiki markup) | .wiki, .mediawiki, .mw | wikicloth                                  |
 | Yajl                    | .yajl                  | yajl-ruby                                  |
 | CSV                     | .rcsv                  | none (Ruby >= 1.9), fastercsv (Ruby < 1.9) |
+| Jbuilder                | .jbuilder              | jbuilder                                   |
+
 These template engines ship with their own Tilt integration:
 
 | Engine                | File Extensions  | Required Libraries  |

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -23,6 +23,7 @@ cross-implementation features.
  * Builder - `Tilt::BuilderTemplate`
  * Markaby - `Tilt::MarkabyTemplate`
  * [Radius](#radius) - `Tilt::RadiusTemplate`
+ * Jbuilder - `Tilt::JbuilderTemplate`
 
 Tilt also includes support for CSS processors like [LessCSS][lesscss] and
 [Sass][sass], [CoffeeScript][coffee-script] and some simple text formats.

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -115,6 +115,7 @@ module Tilt
   register_lazy :CoffeeScriptTemplate, 'tilt/coffee',    'coffee'
   register_lazy :CreoleTemplate,       'tilt/creole',    'wiki', 'creole'
   register_lazy :EtanniTemplate,       'tilt/etanni',    'etn', 'etanni'
+  register_lazy :JbuilderTemplate,     'tilt/jbuilder',  'jbuilder'
   register_lazy :HamlTemplate,         'tilt/haml',      'haml'
   register_lazy :LessTemplate,         'tilt/less',      'less'
   register_lazy :LiquidTemplate,       'tilt/liquid',    'liquid'

--- a/lib/tilt/jbuilder.rb
+++ b/lib/tilt/jbuilder.rb
@@ -1,0 +1,89 @@
+require 'tilt/template'
+require 'jbuilder'
+
+module Tilt
+  # Jbuilder template implementation. See https://github.com/rails/jbuilder.
+  class JbuilderTemplate < Template
+    self.default_mime_type = 'application/json'
+    def prepare; end
+
+    def evaluate(scope, locals, &block)
+      return super(scope, locals, &block) if data.respond_to?(:to_str)
+      json = Tilt::Jbuilder.new(scope, locals)
+      data.call(json)
+      json.target!
+    end
+
+    def precompiled_preamble(locals)
+      return super if locals.include? :json
+      "json = Tilt::Jbuilder.new(self)\n#{super}"
+    end
+
+    def precompiled_postamble(locals)
+      "json.target!"
+    end
+
+    def precompiled_template(locals)
+      data.to_str
+    end
+  end
+
+  # Provides `partial!` functionality in a Tilt context.
+  class Jbuilder < ::Jbuilder
+    def initialize(scope=::Object.new, *args, &block)
+      @scope = scope
+      super(*args, &block)
+    end
+
+    def partial!(name_or_options, locals={})
+      case name_or_options
+      when ::Hash
+        # partial! partial: 'name', locals: { foo: 'bar' }
+        options = name_or_options
+      else
+        # partial! 'name', foo: 'bar'
+        options = { :partial => name_or_options, :locals => locals }
+        as = locals.delete(:as)
+        options[:as] = as if as.present?
+        options[:collection] = locals[:collection] if locals.key?(:collection)
+      end
+      _handle_partial_options options
+    end
+
+    def array!(collection = [], *attributes, &block)
+      options = attributes.extract_options!
+      if options.key?(:partial)
+        partial! options[:partial], options.merge(:collection => collection)
+      else
+        super
+      end
+    end
+
+    private
+
+    def _handle_partial_options(options)
+      options.reverse_merge! :locals => {}
+      as = options[:as]
+
+      if as && options.key?(:collection)
+        collection = options.delete(:collection) || []
+        array!(collection) do |member|
+          options[:locals].merge! as => member
+          options[:locals].merge! :collection => collection
+          _render_partial options
+        end
+      else
+        _render_partial options
+      end
+    end
+
+    def _render_partial(options)
+      locals = options.fetch(:locals)
+      locals.merge! :json => self
+      file = options.fetch(:partial)
+
+      template = ::Tilt::JbuilderTemplate.new(file)
+      template.render(@scope, locals)
+    end
+  end
+end

--- a/test/jbuilder/_locals.jbuilder
+++ b/test/jbuilder/_locals.jbuilder
@@ -1,0 +1,1 @@
+json.thing thing

--- a/test/jbuilder/_partial.jbuilder
+++ b/test/jbuilder/_partial.jbuilder
@@ -1,0 +1,1 @@
+json.foo 'bar'

--- a/test/jbuilder/_scope.jbuilder
+++ b/test/jbuilder/_scope.jbuilder
@@ -1,0 +1,1 @@
+json.beer @beer

--- a/test/tilt_jbuilder_test.rb
+++ b/test/tilt_jbuilder_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper'
+require 'tilt'
+
+begin
+  require 'tilt/jbuilder'
+  class JbuilderTemplateTest < Minitest::Test
+    test "registered for '.jbuilder' files" do
+      assert_equal Tilt::JbuilderTemplate, Tilt['test.jbuilder']
+      assert_equal Tilt::JbuilderTemplate, Tilt['test.json.jbuilder']
+    end
+
+    test "preparing and evaluating the template on #render" do
+      template = Tilt::JbuilderTemplate.new { "json.welcome 'Hello World!'" }
+      assert_equal '{"welcome":"Hello World!"}', template.render
+    end
+
+    test "can be rendered more than once" do
+      template = Tilt::JbuilderTemplate.new { "json.house 'Stark'" }
+      3.times { assert_equal '{"house":"Stark"}', template.render }
+    end
+
+    test "passing locals" do
+      template = Tilt::JbuilderTemplate.new { "json.name name" }
+      assert_equal '{"name":"Ned"}', template.render(Object.new, :name => 'Ned')
+    end
+
+    test "evaluating in an object scope" do
+      template = Tilt::JbuilderTemplate.new { "json.words @words" }
+      scope = Object.new
+      scope.instance_variable_set :@words, 'Winter is Coming.'
+      assert_equal '{"words":"Winter is Coming."}', template.render(scope)
+    end
+
+    test "passing a block for yield" do
+      template = Tilt::JbuilderTemplate.new { "json.bannermen yield" }
+      3.times { assert_equal '{"bannermen":10000}', template.render { 10000 }}
+    end
+
+    test "block style templates" do
+      template =
+        Tilt::JbuilderTemplate.new do |t|
+          lambda { |json| json.battle('Blackwater') }
+        end
+      assert_equal '{"battle":"Blackwater"}', template.render
+    end
+
+    test "render partials with partial!" do
+      template = Tilt::JbuilderTemplate.new {
+        "json.partial! 'test/jbuilder/_partial.jbuilder'"
+      }
+      assert_equal '{"foo":"bar"}', template.render
+    end
+
+    test "render partials with locals" do
+      template = Tilt::JbuilderTemplate.new {
+        "json.partial! 'test/jbuilder/_locals.jbuilder', thing: thing"
+      }
+      assert_equal '{"thing":1}', template.render(Object.new, :thing => 1)
+    end
+
+    test "render partials for a collection" do
+      template = Tilt::JbuilderTemplate.new {
+        "json.things things, partial: 'test/jbuilder/_locals.jbuilder', as: :thing"
+      }
+      assert_equal  '{"things":[{"thing":1},{"thing":2}]}',
+                    template.render(Object.new, :things => [1,2])
+    end
+
+    test "render an array with a partial and a passed-through scope" do
+      template = Tilt::JbuilderTemplate.new {
+        "json.array! @beers, partial: 'test/jbuilder/_scope.jbuilder', as: :beer"
+      }
+      scope = Object.new
+      scope.instance_variable_set :@beers, ['Pabst', 'Coors']
+      scope.instance_variable_set :@beer, 'good'
+      assert_equal '[{"beer":"good"},{"beer":"good"}]', template.render(scope)
+    end
+
+    test "render nested json templates" do
+      inner_temp = Tilt::JbuilderTemplate.new { "json.a ['nice', 'day']" }
+      outer_temp = Tilt::JbuilderTemplate.new { "json.have { yield }" }
+      scope = Object.new
+      locals = { :json => Tilt::Jbuilder.new }
+      rendered = outer_temp.render(scope, locals) {
+        inner_temp.render(scope, locals)
+      }
+      assert_equal  '{"have":{"a":["nice","day"]}}', rendered
+    end
+
+  end
+rescue LoadError
+  warn "Tilt::JbuilderTemplate (disabled)"
+end


### PR DESCRIPTION
This is still a bit of a work in process, but I thought I'd open this up for comments and feedback.

This works mostly as described in https://github.com/rails/jbuilder. The only exception is that the `partial!` method requires a more explicit filename, like Tilt itself does.