### PR TITLE
Literate CoffeeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Support for these template engines is included with the package:
 | Markaby                 | .mab                   | markaby                                    |
 | Nokogiri                | .nokogiri              | nokogiri                                   |
 | CoffeeScript            | .coffee                | coffee-script (+ javascript)               |
+| CoffeeScript (literate) | .litcoffee             | coffee-script (>= 1.5.0) (+ javascript)    |
 | Creole (Wiki markup)    | .wiki, .creole         | creole                                     |
 | WikiCloth (Wiki markup) | .wiki, .mediawiki, .mw | wikicloth                                  |
 | Yajl                    | .yajl                  | yajl-ruby                                  |

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -31,6 +31,7 @@ Tilt also includes support for CSS processors like [LessCSS][lesscss] and
  * Sass - `Tilt::SassTemplate`
  * Scss - `Tilt::ScssTemplate`
  * CoffeeScript - `Tilt::CoffeeScriptTemplate`
+ * Literate CoffeeScript - `Tilt::CoffeeScriptTemplate::Literate`
  * [Textile](#redcloth) - `Tilt::RedClothTemplate`
  * Creole - `Tilt::CreoleTemplate`
  * [RDoc](#rdoc) - `Tilt::RDocTemplate`

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -109,10 +109,12 @@ module Tilt
   register_lazy :RedcarpetTemplate,  'tilt/redcarpet', 'markdown', 'mkd', 'md'
 
   # Rest (sorted by name)
+  litcoffee = 'CoffeeScriptTemplate::Literate'
   register_lazy :AsciidoctorTemplate,  'tilt/asciidoc',  'ad', 'adoc', 'asciidoc'
   register_lazy :BuilderTemplate,      'tilt/builder',   'builder'
   register_lazy :CSVTemplate,          'tilt/csv',       'rcsv'
   register_lazy :CoffeeScriptTemplate, 'tilt/coffee',    'coffee'
+  register_lazy litcoffee,             'tilt/coffee',    'litcoffee'
   register_lazy :CreoleTemplate,       'tilt/creole',    'wiki', 'creole'
   register_lazy :EtanniTemplate,       'tilt/etanni',    'etn', 'etanni'
   register_lazy :HamlTemplate,         'tilt/haml',      'haml'

--- a/lib/tilt/coffee.rb
+++ b/lib/tilt/coffee.rb
@@ -29,10 +29,23 @@ module Tilt
       @@default_bare = value
     end
 
+    def self.literate?
+      false
+    end
+
+    def self.engine_initialized?
+      defined? ::CoffeeScript
+    end
+
+    def initialize_engine
+      require_template_library 'coffee_script'
+    end
+
     def prepare
       if !options.key?(:bare) and !options.key?(:no_wrap)
         options[:bare] = self.class.default_bare
       end
+      options[:literate] ||= self.class.literate?
     end
 
     def evaluate(scope, locals, &block)
@@ -41,6 +54,12 @@ module Tilt
 
     def allows_script?
       false
+    end
+
+    class Literate < CoffeeScriptTemplate
+      def self.literate?
+        true
+      end
     end
   end
 end

--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -6,64 +6,68 @@ begin
 
   class CoffeeScriptTemplateTest < Minitest::Test
 
+    setup do
+      @code_without_variables = "puts 'Hello, World!'\n"
+      @code_with_variables = 'name = "Josh"; puts "Hello, #{name}"'
+      @renderer = Tilt::CoffeeScriptTemplate
+    end
+
     test "is registered for '.coffee' files" do
-      assert_equal Tilt::CoffeeScriptTemplate, Tilt['test.coffee']
+      assert_equal @renderer, Tilt['test.coffee']
     end
 
     test "bare is disabled by default" do
-      assert_equal false, Tilt::CoffeeScriptTemplate.default_bare
+      assert_equal false, @renderer.default_bare
     end
 
     test "compiles and evaluates the template on #render" do
-      template = Tilt::CoffeeScriptTemplate.new { |t| "puts 'Hello, World!'\n" }
+      template = @renderer.new { |t| @code_without_variables }
       assert_match "puts('Hello, World!');", template.render
     end
 
     test "can be rendered more than once" do
-      template = Tilt::CoffeeScriptTemplate.new { |t| "puts 'Hello, World!'\n" }
+      template = @renderer.new { |t| @code_without_variables }
       3.times { assert_match "puts('Hello, World!');", template.render }
     end
 
     test "disabling coffee-script wrapper" do
-      str = 'name = "Josh"; puts "Hello #{name}"'
-
-      template = Tilt::CoffeeScriptTemplate.new { str }
+      template = @renderer.new { @code_with_variables }
       assert_match "(function() {", template.render
-      assert_match "puts(\"Hello \" + name);\n", template.render
+      assert_match "puts(\"Hello, \" + name);\n", template.render
 
-      template = Tilt::CoffeeScriptTemplate.new(:bare => true) { str }
-      refute_match "(function() {", template.render
-      assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello \" + name);\n", template.render
+      template = @renderer.new(:bare => true) { @code_with_variables }
+      assert_not_match "(function() {", template.render
+      assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello, \" + name);\n", template.render
 
-      template2 = Tilt::CoffeeScriptTemplate.new(:no_wrap => true) { str}
-      refute_match "(function() {", template.render
-      assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello \" + name);\n", template.render
+      template2 = @renderer.new(:no_wrap => true) { @code_with_variables}
+      assert_not_match "(function() {", template.render
+      assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello, \" + name);\n", template.render
     end
 
     context "wrapper globally enabled" do
       setup do
-        @bare = Tilt::CoffeeScriptTemplate.default_bare
-        Tilt::CoffeeScriptTemplate.default_bare = false
+        @bare = @renderer.default_bare
+        @renderer.default_bare = false
       end
 
       teardown do
-        Tilt::CoffeeScriptTemplate.default_bare = @bare
+        @renderer.default_bare = @bare
       end
 
       test "no options" do
-        template = Tilt::CoffeeScriptTemplate.new { |t| 'name = "Josh"; puts "Hello, #{name}"' }
+        template = @renderer.new { |t| @code_with_variables }
         assert_match "puts(\"Hello, \" + name);", template.render
         assert_match "(function() {", template.render
       end
 
       test "overridden by :bare" do
-        template = Tilt::CoffeeScriptTemplate.new(:bare => true) { |t| 'name = "Josh"; puts "Hello, #{name}"' }
+        template = @renderer.new(:bare => true) { |t| @code_with_variables }
         assert_match "puts(\"Hello, \" + name);", template.render
         refute_match "(function() {", template.render
       end
 
       test "overridden by :no_wrap" do
-        template = Tilt::CoffeeScriptTemplate.new(:no_wrap => true) { |t| 'name = "Josh"; puts "Hello, #{name}"' }
+        template = @renderer.new(:no_wrap => true) { |t| @code_with_variables }
         assert_match "puts(\"Hello, \" + name);", template.render
         refute_match "(function() {", template.render
       end
@@ -71,28 +75,28 @@ begin
 
     context "wrapper globally disabled" do
       setup do
-        @bare = Tilt::CoffeeScriptTemplate.default_bare
-        Tilt::CoffeeScriptTemplate.default_bare = true
+        @bare = @renderer.default_bare
+        @renderer.default_bare = true
       end
 
       teardown do
-        Tilt::CoffeeScriptTemplate.default_bare = @bare
+        @renderer.default_bare = @bare
       end
 
       test "no options" do
-        template = Tilt::CoffeeScriptTemplate.new { |t| 'name = "Josh"; puts "Hello, #{name}"' }
+        template = @renderer.new { |t| @code_with_variables }
         assert_match "puts(\"Hello, \" + name);", template.render
         refute_match "(function() {", template.render
       end
 
       test "overridden by :bare" do
-        template = Tilt::CoffeeScriptTemplate.new(:bare => false) { |t| 'name = "Josh"; puts "Hello, #{name}"' }
+        template = @renderer.new(:bare => false) { |t| @code_with_variables }
         assert_match "puts(\"Hello, \" + name);", template.render
         assert_match "(function() {", template.render
       end
 
       test "overridden by :no_wrap" do
-        template = Tilt::CoffeeScriptTemplate.new(:no_wrap => false) { |t| 'name = "Josh"; puts "Hello, #{name}"' }
+        template = @renderer.new(:no_wrap => false) { |t| @code_with_variables }
         assert_match "puts(\"Hello, \" + name);", template.render
         assert_match "(function() {", template.render
       end

--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -4,102 +4,119 @@ require 'tilt'
 begin
   require 'tilt/coffee'
 
-  class CoffeeScriptTemplateTest < Minitest::Test
+  module CoffeeScriptTests
+    def self.included(mod)
+      mod.class_eval do
+        unless method_defined?(:assert_not_match)
+          # assert_not_match is missing on 1.8.7, which uses assert_no_match
+          def assert_not_match(a, b)
+            unless a.kind_of?(Regexp)
+              a = Regexp.new(Regexp.escape(a))
+            end
+            assert_no_match(a,b)
+          end
+        end
 
+        test "bare is disabled by default" do
+          assert_equal false, @renderer.default_bare
+        end
+
+        test "compiles and evaluates the template on #render" do
+          template = @renderer.new { |t| @code_without_variables }
+          assert_match "puts('Hello, World!');", template.render
+        end
+
+        test "can be rendered more than once" do
+          template = @renderer.new { |t| @code_without_variables }
+          3.times { assert_match "puts('Hello, World!');", template.render }
+        end
+
+        test "disabling coffee-script wrapper" do
+          template = @renderer.new { @code_with_variables }
+          assert_match "(function() {", template.render
+          assert_match "puts(\"Hello, \" + name);\n", template.render
+
+          template = @renderer.new(:bare => true) { @code_with_variables }
+          assert_not_match "(function() {", template.render
+          assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello, \" + name);\n", template.render
+
+          template2 = @renderer.new(:no_wrap => true) { @code_with_variables}
+          assert_not_match "(function() {", template.render
+          assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello, \" + name);\n", template.render
+        end
+
+        context "wrapper globally enabled" do
+          setup do
+            @bare = @renderer.default_bare
+            @renderer.default_bare = false
+          end
+
+          teardown do
+            @renderer.default_bare = @bare
+          end
+
+          test "no options" do
+            template = @renderer.new { |t| @code_with_variables }
+            assert_match "puts(\"Hello, \" + name);", template.render
+            assert_match "(function() {", template.render
+          end
+
+          test "overridden by :bare" do
+            template = @renderer.new(:bare => true) { |t| @code_with_variables }
+            assert_match "puts(\"Hello, \" + name);", template.render
+            assert_not_match "(function() {", template.render
+          end
+
+          test "overridden by :no_wrap" do
+            template = @renderer.new(:no_wrap => true) { |t| @code_with_variables }
+            assert_match "puts(\"Hello, \" + name);", template.render
+            assert_not_match "(function() {", template.render
+          end
+        end
+
+        context "wrapper globally disabled" do
+          setup do
+            @bare = @renderer.default_bare
+            @renderer.default_bare = true
+          end
+
+          teardown do
+            @renderer.default_bare = @bare
+          end
+
+          test "no options" do
+            template = @renderer.new { |t| @code_with_variables }
+            assert_match "puts(\"Hello, \" + name);", template.render
+            assert_not_match "(function() {", template.render
+          end
+
+          test "overridden by :bare" do
+            template = @renderer.new(:bare => false) { |t| @code_with_variables }
+            assert_match "puts(\"Hello, \" + name);", template.render
+            assert_match "(function() {", template.render
+          end
+
+          test "overridden by :no_wrap" do
+            template = @renderer.new(:no_wrap => false) { |t| @code_with_variables }
+            assert_match "puts(\"Hello, \" + name);", template.render
+            assert_match "(function() {", template.render
+          end
+        end
+      end
+    end
+  end
+
+  class CoffeeScriptTemplateTest < Test::Unit::TestCase
     setup do
       @code_without_variables = "puts 'Hello, World!'\n"
       @code_with_variables = 'name = "Josh"; puts "Hello, #{name}"'
       @renderer = Tilt::CoffeeScriptTemplate
     end
 
+    include CoffeeScriptTests
+
     test "is registered for '.coffee' files" do
       assert_equal @renderer, Tilt['test.coffee']
-    end
-
-    test "bare is disabled by default" do
-      assert_equal false, @renderer.default_bare
-    end
-
-    test "compiles and evaluates the template on #render" do
-      template = @renderer.new { |t| @code_without_variables }
-      assert_match "puts('Hello, World!');", template.render
-    end
-
-    test "can be rendered more than once" do
-      template = @renderer.new { |t| @code_without_variables }
-      3.times { assert_match "puts('Hello, World!');", template.render }
-    end
-
-    test "disabling coffee-script wrapper" do
-      template = @renderer.new { @code_with_variables }
-      assert_match "(function() {", template.render
-      assert_match "puts(\"Hello, \" + name);\n", template.render
-
-      template = @renderer.new(:bare => true) { @code_with_variables }
-      assert_not_match "(function() {", template.render
-      assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello, \" + name);\n", template.render
-
-      template2 = @renderer.new(:no_wrap => true) { @code_with_variables}
-      assert_not_match "(function() {", template.render
-      assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello, \" + name);\n", template.render
-    end
-
-    context "wrapper globally enabled" do
-      setup do
-        @bare = @renderer.default_bare
-        @renderer.default_bare = false
-      end
-
-      teardown do
-        @renderer.default_bare = @bare
-      end
-
-      test "no options" do
-        template = @renderer.new { |t| @code_with_variables }
-        assert_match "puts(\"Hello, \" + name);", template.render
-        assert_match "(function() {", template.render
-      end
-
-      test "overridden by :bare" do
-        template = @renderer.new(:bare => true) { |t| @code_with_variables }
-        assert_match "puts(\"Hello, \" + name);", template.render
-        refute_match "(function() {", template.render
-      end
-
-      test "overridden by :no_wrap" do
-        template = @renderer.new(:no_wrap => true) { |t| @code_with_variables }
-        assert_match "puts(\"Hello, \" + name);", template.render
-        refute_match "(function() {", template.render
-      end
-    end
-
-    context "wrapper globally disabled" do
-      setup do
-        @bare = @renderer.default_bare
-        @renderer.default_bare = true
-      end
-
-      teardown do
-        @renderer.default_bare = @bare
-      end
-
-      test "no options" do
-        template = @renderer.new { |t| @code_with_variables }
-        assert_match "puts(\"Hello, \" + name);", template.render
-        refute_match "(function() {", template.render
-      end
-
-      test "overridden by :bare" do
-        template = @renderer.new(:bare => false) { |t| @code_with_variables }
-        assert_match "puts(\"Hello, \" + name);", template.render
-        assert_match "(function() {", template.render
-      end
-
-      test "overridden by :no_wrap" do
-        template = @renderer.new(:no_wrap => false) { |t| @code_with_variables }
-        assert_match "puts(\"Hello, \" + name);", template.render
-        assert_match "(function() {", template.render
-      end
     end
   end
 


### PR DESCRIPTION
I rebased pull request #173 on the latest master branch to enable Literate CoffeeScript in Tilt 2.x.

## Using Literate CoffeeScript in a Rails app
### Configure Sprockets
You'll still have to tell Sprockets what to do with `.litcoffee` files [as described by Skalee](https://github.com/rtomayko/tilt/pull/173#issuecomment-14238077); a Sprockets developer stated in sstephenson/sprockets#420 that `.litcoffee` support won't be enabled by default.

### Update Gemfile
For now, you also have to update your Gemfile to use the `mr-vinn/tilt` repo.  However, Tilt is locked to 1.4.1 in the latest stable Rails version (4.1.5), so I applied these commits to Tilt 1.4.1 in a different branch.  Add this to your Gemfile to get a litcoffee-enabled Tilt 1.4.1:

    group :assets do
      gem 'tilt', github: 'mr-vinn/tilt', branch: '1.4.1-litcoffee'
    end