### PR TITLE
Add support for Redcarpet render options.

### DIFF
--- a/lib/tilt/redcarpet.rb
+++ b/lib/tilt/redcarpet.rb
@@ -40,7 +40,7 @@ module Tilt
     end
 
     def generate_renderer
-      renderer = options.delete(:renderer) || ::Redcarpet::Render::HTML
+      renderer = options.delete(:renderer) || ::Redcarpet::Render::HTML.new(options)
       return renderer unless options.delete(:smartypants)
       return renderer if renderer.is_a?(Class) && renderer <= ::Redcarpet::Render::SmartyPants
 

--- a/test/tilt_markdown_test.rb
+++ b/test/tilt_markdown_test.rb
@@ -91,13 +91,16 @@ begin
   class MarkdownRedcarpetTest < Minitest::Test
     include MarkdownTests
     template Tilt::RedcarpetTemplate
-    # Doesn't support escaping
-    undef test_escape_html_true
 
     def test_smarty_pants_true
       # Various versions of Redcarpet support various versions of Smart pants.
       html = nrender "Hello ``World'' -- This is --- a test ...", :smartypants => true
       assert_match /<p>Hello “World(''|”) – This is — a test …<\/p>/, html
+    end
+
+    def test_renderer_options
+      html = nrender "Hello [World](http://example.com)", :smartypants => true, :no_links => true
+      assert_equal "<p>Hello [World](http://example.com)</p>", html
     end
 
     def test_fenced_code_blocks_with_lang


### PR DESCRIPTION
Fixes [Redcarpet render options](https://github.com/vmg/redcarpet#darling-i-packed-you-a-couple-renderers-for-lunch) which weren't being passed along. Re-added the `escape_html` test, which is one of the render options. Also related #238.

