### PR TITLE
Make Tilt::Cache return nil when nil is found in the cache.

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -85,7 +85,9 @@ module Tilt
 
     # @see Cache
     def fetch(*key)
-      @cache[key] ||= yield
+      @cache.fetch(key) do
+        @cache[key] = yield
+      end
     end
 
     # Clears the cache.

--- a/test/tilt_cache_test.rb
+++ b/test/tilt_cache_test.rb
@@ -20,6 +20,17 @@ class TiltCacheTest < Minitest::Test
     assert_same template, result
   end
 
+  test "caching nil" do
+    called = false
+    result = @cache.fetch("blah") {called = true; nil}
+    assert_equal true, called
+    assert_nil result
+    called = false
+    result = @cache.fetch("blah") {called = true; :blah}
+    assert_equal false, called
+    assert_nil result
+  end
+
   test "clearing the cache with #clear" do
     template, other = nil
     result = @cache.fetch('hello') { template = Tilt::StringTemplate.new {''} }


### PR DESCRIPTION
This avoids calling the block again with the same arguments and having it
do some possibly expensive processing only to return nil again.

Sorry if this is a frequently requested pull.