### PR TITLE
Allow passing outvar and csv options.

### DIFF
--- a/lib/tilt/csv.rb
+++ b/lib/tilt/csv.rb
@@ -45,15 +45,15 @@ module Tilt
     end
 
     def prepare
-      @code =<<-RUBY
-        #{self.class.engine}.generate do |csv|
-          #{data}
-        end
-      RUBY
+      @outvar = options.delete(:outvar) || '_csvout'
     end
 
     def precompiled_template(locals)
-      @code
+      <<-RUBY
+        #{@outvar} = #{self.class.engine}.generate(#{options}) do |csv|
+          #{data}
+        end
+      RUBY
     end
 
     def precompiled(locals)

--- a/test/tilt_csv_test.rb
+++ b/test/tilt_csv_test.rb
@@ -47,6 +47,18 @@ begin
       end
     end
 
+    test "passing options to engine" do
+      template = Tilt::CSVTemplate.new(col_sep: '|') { 'csv << [1,2,3]' }
+      assert_equal "1|2|3\n", template.render
+    end
+
+    test "outvar option" do
+      outvar = '@_output'
+      scope = Object.new
+      template = Tilt::CSVTemplate.new(outvar: outvar) { 'csv << [1,2,3]' }
+      output = template.render(scope)
+      assert_equal output, scope.instance_variable_get(outvar.to_sym)
+    end
   end
 
 rescue LoadError => boom


### PR DESCRIPTION
Now it is possible to pass options (such as 'col_sep') directly to
csv engine.

In addition, if 'outvar' option is present, template output will be
stored in the provided variable.