### PR TITLE
Ruby 2.2: Tilt::HamlTemplate#render shouldn't blow up on explicit nil

### DIFF
--- a/lib/tilt/haml.rb
+++ b/lib/tilt/haml.rb
@@ -13,6 +13,8 @@ module Tilt
     end
 
     def evaluate(scope, locals, &block)
+      raise ArgumentError, 'invalid scope: must not be frozen' if scope.frozen?
+
       if @engine.respond_to?(:precompiled_method_return_value, true)
         super
       else
@@ -54,4 +56,3 @@ module Tilt
     end
   end
 end
-

--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -92,7 +92,8 @@ module Tilt
     # Render the template in the given scope with the locals specified. If a
     # block is given, it is typically available within the template via
     # +yield+.
-    def render(scope=Object.new, locals={}, &block)
+    def render(scope=nil, locals={}, &block)
+      scope ||= Object.new
       current_template = Thread.current[:tilt_current_template]
       Thread.current[:tilt_current_template] = self
       evaluate(scope, locals || {}, &block)

--- a/test/tilt_hamltemplate_test.rb
+++ b/test/tilt_hamltemplate_test.rb
@@ -33,6 +33,11 @@ begin
       assert_equal "<p>Hey unknown!</p>\n", template.render(nil)
     end
 
+    test 'evaluating in invalid, frozen scope' do
+      template = Tilt::HamlTemplate.new { |t| '%p Hey unknown!' }
+      assert_raises(ArgumentError) { template.render(Object.new.freeze) }
+    end
+
     test "evaluating in an object scope" do
       template = Tilt::HamlTemplate.new { "%p= 'Hey ' + @name + '!'" }
       scope = Object.new
@@ -97,6 +102,11 @@ begin
       template = Tilt::HamlTemplate.new { |t| '%p Hey unknown!' }
       assert_equal "<p>Hey unknown!</p>\n", template.render
       assert_equal "<p>Hey unknown!</p>\n", template.render(nil)
+    end
+
+    test 'evaluating in invalid, frozen scope' do
+      template = Tilt::HamlTemplate.new { |t| '%p Hey unknown!' }
+      assert_raises(ArgumentError) { template.render(Object.new.freeze) }
     end
 
     test "evaluating in an object scope" do

--- a/test/tilt_hamltemplate_test.rb
+++ b/test/tilt_hamltemplate_test.rb
@@ -27,6 +27,12 @@ begin
       assert_equal "<p>Hey Joe!</p>\n", template.render(Object.new, :name => 'Joe')
     end
 
+    test 'evaluating in default/nil scope' do
+      template = Tilt::HamlTemplate.new { |t| '%p Hey unknown!' }
+      assert_equal "<p>Hey unknown!</p>\n", template.render
+      assert_equal "<p>Hey unknown!</p>\n", template.render(nil)
+    end
+
     test "evaluating in an object scope" do
       template = Tilt::HamlTemplate.new { "%p= 'Hey ' + @name + '!'" }
       scope = Object.new
@@ -85,6 +91,12 @@ begin
     test "passing locals" do
       template = Tilt::HamlTemplate.new { "%p= 'Hey ' + name + '!'" }
       assert_equal "<p>Hey Joe!</p>\n", template.render(Scope.new, :name => 'Joe')
+    end
+
+    test 'evaluating in default/nil scope' do
+      template = Tilt::HamlTemplate.new { |t| '%p Hey unknown!' }
+      assert_equal "<p>Hey unknown!</p>\n", template.render
+      assert_equal "<p>Hey unknown!</p>\n", template.render(nil)
     end
 
     test "evaluating in an object scope" do

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -122,6 +122,12 @@ class TiltTemplateTest < Minitest::Test
     assert inst.prepared?
   end
 
+  test 'prepares and evaluates the template on #render with nil arg' do
+    inst = SimpleMockTemplate.new { |t| "Hello World!" }
+    assert_equal '<em>Hello World!</em>', inst.render(nil)
+    assert inst.prepared?
+  end
+
   class SourceGeneratingMockTemplate < PreparingMockTemplate
     def precompiled_template(locals)
       "foo = [] ; foo << %Q{#{data}} ; foo.join"


### PR DESCRIPTION
To reproduce:

```ruby
require 'tilt'

t = Tilt::HamlTemplate.new do
  '%h1'
end
p t.render(nil)
```

**Output: Ruby 2.1**:
```
<h1></h1>
```

**Output: Ruby 2.2**:
```
(__TEMPLATE__):4:in `ensure in block in singleton class': undefined method `upper' for nil:NilClass (NoMethodError)
	from (__TEMPLATE__):4:in `block in singleton class'
	from (__TEMPLATE__):-9:in `instance_eval'
	from (__TEMPLATE__):-9:in `singleton class'
	from (__TEMPLATE__):-11:in `__tilt_70265677939160'
	from /Users/alexbcoles/.gem/ruby/2.2.0/gems/tilt-2.0.1/lib/tilt/template.rb:155:in `call'
	from /Users/alexbcoles/.gem/ruby/2.2.0/gems/tilt-2.0.1/lib/tilt/template.rb:155:in `evaluate'
	from /Users/alexbcoles/.gem/ruby/2.2.0/gems/tilt-2.0.1/lib/tilt/haml.rb:17:in `evaluate'
	from /Users/alexbcoles/.gem/ruby/2.2.0/gems/tilt-2.0.1/lib/tilt/template.rb:96:in `render'
	from test_case.rb:15:in `<main>'
```