### PR TITLE
Add Tilt::Mapping#pipeline for handling template pipelines

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -28,6 +28,11 @@ module Tilt
     default_mapping.register_lazy(class_name, file, *extensions)
   end
 
+  # @see Tilt::Mapping#register_pipeline
+  def self.register_pipeline(ext, options={})
+    default_mapping.register_pipeline(ext, options)
+  end
+
   # @deprecated Use {register} instead.
   def self.prefer(template_class, *extensions)
     register(template_class, *extensions)

--- a/lib/tilt/pipeline.rb
+++ b/lib/tilt/pipeline.rb
@@ -1,0 +1,18 @@
+require_relative 'template'
+
+module Tilt
+  # Superclass used for pipeline templates.  Should not be used directly.
+  class Pipeline < Template
+    def prepare
+      @pipeline = self.class::TEMPLATES.inject(proc{|*| data}) do |data, (klass, options)|
+        proc do |s,l,&sb|
+          klass.new(file, line, options, &proc{|*| data.call(s, l, &sb)}).render(s, l, &sb)
+        end
+      end
+    end
+
+    def evaluate(scope, locals, &block)
+      @pipeline.call(scope, locals, &block)
+    end
+  end
+end

--- a/test/tilt_pipeline_test.rb
+++ b/test/tilt_pipeline_test.rb
@@ -1,0 +1,70 @@
+require_relative 'test_helper'
+
+class PipelineTest < Minitest::Test
+  setup do
+    @mapping = Tilt.default_mapping.dup
+    @pipeline_class = @mapping.register_pipeline('str.erb')
+  end
+
+  test "returns a template class" do
+    assert_equal Tilt::Pipeline, @pipeline_class.superclass
+  end
+
+  test "registers itself for the given extension" do
+    assert_equal @pipeline_class, @mapping['test.str.erb']
+  end
+
+  test "renders templates starting with final extension to inner extensions" do
+    template = @pipeline_class.new { |t| '#<%= \'{a = 1}\' %><%= \'#{a}\' %>' }
+    assert_equal "11", template.render
+  end
+
+  test "can be rendered more than once" do
+    template = @pipeline_class.new { |t| '<%= \'#{1}\' %>' }
+    3.times { assert_equal "1", template.render }
+  end
+
+  test "passing locals" do
+    template = @pipeline_class.new { |t| '<%= \'#{a}\' * a %>' }
+    assert_equal "333", template.render(Object.new, :a => 3)
+  end
+
+  test "evaluating in an object scope" do
+    template = @pipeline_class.new { |t| '<%= \'#{a}\' * a %>' }
+    o = Object.new
+    def o.a; 3 end
+    assert_equal "333", template.render(o)
+  end
+
+  test "passing a block for yield" do
+    template = @pipeline_class.new { |t| '<%= \'#{yield}\' * yield %>' }
+    assert_equal "333", template.render { 3 }
+    assert_equal "22", template.render { 2 }
+  end
+end
+
+class PipelineOptionsTest < Minitest::Test
+  setup do
+    @mapping = Tilt.default_mapping.dup
+  end
+
+  test "supports :templates option for specifying templates to use in order" do
+    pipeline = @mapping.register_pipeline('setrrb', :templates=>['erb', 'str'])
+    template = pipeline.new { |t| '#<%= \'{a = 1}\' %><%= \'#{a}\' %>' }
+    assert_equal "11", template.render
+  end
+
+  test "supports :extra_exts option for specifying additional extensions to register" do
+    @mapping.register_pipeline('str.erb', :extra_exts=>['setrrb', 'asdfoa'])
+    ['str.erb', 'setrrb', 'asdfoa'].each do |ext|
+      template = @mapping[ext].new { |t| '#<%= \'{a = 1}\' %><%= \'#{a}\' %>' }
+      assert_equal "11", template.render
+    end
+  end
+
+  test "supports per template class options" do
+    pipeline = @mapping.register_pipeline('str.erb', 'erb'=>{:outvar=>'@foo'})
+    template = pipeline.new { |t| '#<% @foo << \'{a = 1}\' %><%= \'#{a}\' %>' }
+    assert_equal "11", template.render
+  end
+end


### PR DESCRIPTION
This makes it easy to combine multiple template engines into
a single processing pipeline, by taking the output of one
template and using it as the input to another template,
returning the final output as the result of the pipeline.

As this is self contained, it could easily be implemented as
an external gem.  However, I think the functionality is useful
and you may want to ship it with Tilt, so I thought I'd send
a pull request here before trying to package it as an
external gem.
