### PR TITLE
Fixes for failing tests for wikicloth.

### DIFF
--- a/test/tilt_wikiclothtemplate_test.rb
+++ b/test/tilt_wikiclothtemplate_test.rb
@@ -19,12 +19,12 @@ begin
 
     test "compiles and evaluates the template on #render" do
       template = Tilt::WikiClothTemplate.new { |t| "= Hello World! =" }
-      assert_match /<h1>.*Hello World!.*<\/h1>/, template.render
+      assert_match /<h1>.*Hello World!.*<\/h1>/m, template.render
     end
 
     test "can be rendered more than once" do
       template = Tilt::WikiClothTemplate.new { |t| "= Hello World! =" }
-      3.times { assert_match /<h1>.*Hello World!.*<\/h1>/, template.render }
+      3.times { assert_match /<h1>.*Hello World!.*<\/h1>/m, template.render }
     end
   end
 rescue LoadError => boom


### PR DESCRIPTION
The fix is very simple. Added m to the regex to match on new lines by replacing

    /<h1>.*Hello World!.*<\/h1>/

with

    /<h1>.*Hello World!.*<\/h1>/m

This fixes the regex failing to match on leading and trailing newlines.