### PR TITLE
Add mimetype to BabelTemplate

### DIFF
--- a/lib/tilt/babel.rb
+++ b/lib/tilt/babel.rb
@@ -3,6 +3,8 @@ require 'babel/transpiler'
 
 module Tilt
   class BabelTemplate < Template
+    self.default_mime_type = 'application/javascript'
+
     def prepare
       options[:filename] ||= file
     end
@@ -12,4 +14,3 @@ module Tilt
     end
   end
 end
-


### PR DESCRIPTION
Before the v2.0.1, I have my BabelTemplate implementation. But when the v2.0.2 released, my gem failed with:

```bash
/Users/saito/.rvm/gems/ruby-2.3.0/gems/linner-0.11.2/lib/linner/template.rb:17:in `<module:Tilt>': superclass mismatch for class BabelTemplate (TypeError)
	from /Users/saito/.rvm/gems/ruby-2.3.0/gems/linner-0.11.2/lib/linner/template.rb:8:in `<top (required)>'
	from /Users/saito/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /Users/saito/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /Users/saito/.rvm/gems/ruby-2.3.0/gems/linner-0.11.2/lib/linner.rb:11:in `<top (required)>'
	from /Users/saito/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:120:in `require'
	from /Users/saito/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:120:in `require'
	from /Users/saito/.rvm/gems/ruby-2.3.0/gems/linner-0.11.2/bin/linner:10:in `<top (required)>'
	from /Users/saito/.rvm/gems/ruby-2.3.0/bin/linner:23:in `load'
	from /Users/saito/.rvm/gems/ruby-2.3.0/bin/linner:23:in `<main>'
```

The luckiest thing is: our implementation are very very similar, except that my version has mimetype for the BabelTemplate.

In my gem, I really need this mimetype to work with, so, can we add it in the official version? 