### PR TITLE
Add pandoc support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :secondary do
   gem 'asciidoctor', '>= 0.1.0'
   gem 'liquid'
   gem 'maruku'
+  gem 'pandoc-ruby'
 
   if RUBY_VERSION > '1.9.3'
     gem 'prawn', '>= 2.0.0'

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Support for these template engines is included with the package:
 | Redcarpet               | .markdown, .mkd, .md   | redcarpet                                  | Community   |
 | BlueCloth               | .markdown, .mkd, .md   | bluecloth                                  | Community   |
 | Kramdown                | .markdown, .mkd, .md   | kramdown                                   | Community   |
+| Pandoc                  | .markdown, .mkd, .md   | pandoc                                     | Community   |
 | Maruku                  | .markdown, .mkd, .md   | maruku                                     | Community   |
 | RedCloth                | .textile               | redcloth                                   | Community   |
 | RDoc                    | .rdoc                  | rdoc                                       | Tilt team   |

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -44,6 +44,7 @@ implementations (depending on which are available on your system):
  * Redcarpet - `Tilt::RedcarpetTemplate`
  * BlueCloth - `Tilt::BlueClothTemplate`
  * Kramdown - `Tilt::KramdownTemplate`
+ * Pandoc - `Tilt::PandocTemplate`
  * Maruku - `Tilt::MarukuTemplate`
 
 <a name='erb'></a>
@@ -432,6 +433,7 @@ Markdown formatted texts are converted to HTML with one of these libraries:
   * Redcarpet - `Tilt::RedcarpetTemplate`
   * BlueCloth - `Tilt::BlueClothTemplate`
   * Kramdown - `Tilt::KramdownTemplate`
+  * Pandoc - `Tilt::PandocTemplate`
   * Maruku - `Tilt::MarukuTemplate`
 
 Tilt will use fallback mode (as documented in the README) for determining which
@@ -458,7 +460,7 @@ To wrap a Markdown formatted document with a layout:
 ### Options
 
 Every implementation of Markdown *should* support these options, but there are
-some known problems with the Kramdown and Maruku engines. 
+some known problems with the Kramdown and Maruku engines.
 
 #### `:smartypants => true|false`
 
@@ -521,4 +523,3 @@ using this template engine within a threaded environment.
 [rdiscount]: http://github.com/rtomayko/rdiscount/ "RDiscount"
 [smartypants]: http://daringfireball.net/projects/smartypants/ "Smarty Pants"
 [markdown]: http://en.wikipedia.org/wiki/Markdown "Markdown"
-

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -476,7 +476,7 @@ Maruku ignores this option and always applies smart quotes (and nothing else).
 Set `true` disallow raw HTML in Markdown contents. HTML is converted to
 literal text by escaping `<` characters.
 
-Kramdown and Maruku doesn't support this option.
+Kramdown, Maruku and Pandoc don't support this option.
 
 ### See also
 

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -460,7 +460,7 @@ To wrap a Markdown formatted document with a layout:
 ### Options
 
 Every implementation of Markdown *should* support these options, but there are
-some known problems with the Kramdown and Maruku engines.
+some known problems with the Kramdown, Maruku and Pandoc engines.
 
 #### `:smartypants => true|false`
 

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -120,6 +120,7 @@ module Tilt
 
   # Markdown
   register_lazy :BlueClothTemplate,  'tilt/bluecloth', 'markdown', 'mkd', 'md'
+  register_lazy :PandocTemplate,     'tilt/pandoc',    'markdown', 'mkd', 'md'
   register_lazy :MarukuTemplate,     'tilt/maruku',    'markdown', 'mkd', 'md'
   register_lazy :KramdownTemplate,   'tilt/kramdown',  'markdown', 'mkd', 'md'
   register_lazy :RDiscountTemplate,  'tilt/rdiscount', 'markdown', 'mkd', 'md'

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -26,7 +26,7 @@ module Tilt
 
     def options_hash
       options.inject({}) do |hash, option|
-        hash[option[0]] = option[1] unless option[1] === true
+        hash[option[0]] = option[1] unless option[1] === true or option[1] === false
         hash
       end
     end

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -6,8 +6,7 @@ module Tilt
   # http://pandoc.org/
   class PandocTemplate < Template
     def prepare
-      # What about the options?
-      @output = PandocRuby.convert(data, to: :html).strip
+      @output = PandocRuby.convert(data, {:to => :html}, *options).strip
     end
 
     def evaluate(scope, locals, &block)

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -9,12 +9,16 @@ module Tilt
       @output = PandocRuby.convert(data, options_hash, *options_array).strip
     end
 
+    def tilt_to_pandoc_mapping
+      { :smartypants => [:smart, true],
+        :escape_html => [:f, 'markdown-raw_html']
+      }
+    end
+
     def pandoc_optimised_options
       options.inject({}) do |hash, option|
-        if option[0] == :smartypants
-          hash[:smart] = true if option[1] === true
-        elsif option[0] == :escape_html
-          hash[:f] = 'markdown-raw_html' if option[1] === true
+        if tilt_to_pandoc_mapping.has_key?(option[0]) && option[1] === true
+          hash[tilt_to_pandoc_mapping[option[0]][0]] = tilt_to_pandoc_mapping[option[0]][1]
         else
           hash[option[0]] = option[1]
         end

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -1,0 +1,21 @@
+require 'tilt/template'
+require 'pandoc-ruby'
+
+module Tilt
+  # Pandoc markdown implementation. See:
+  # http://pandoc.org/
+  class PandocTemplate < Template
+    def prepare
+      # What about the options?
+      @output = PandocRuby.convert(data, to: :html).strip
+    end
+
+    def evaluate(scope, locals, &block)
+      @output
+    end
+
+    def allows_script?
+      false
+    end
+  end
+end

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -6,7 +6,29 @@ module Tilt
   # http://pandoc.org/
   class PandocTemplate < Template
     def prepare
-      @output = PandocRuby.convert(data, {:to => :html}, *options).strip
+      @output = PandocRuby.convert(data, options_hash.merge(
+                                           {:to => :html}
+                                         ), *options_array
+                                  ).strip
+    end
+
+    def tilt_to_pandoc_mapping
+      { :smartypants => :smart,
+        :escape_html => :markdown_strict
+      }
+    end
+
+    def options_array
+      options.map do |option|
+        tilt_to_pandoc_mapping[option[0]] || option[0] if option[1] === true
+      end.compact
+    end
+
+    def options_hash
+      options.inject({}) do |hash, option|
+        hash[option[0]] = option[1] unless option[1] === true
+        hash
+      end
     end
 
     def evaluate(scope, locals, &block)

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -13,9 +13,7 @@ module Tilt
     end
 
     def tilt_to_pandoc_mapping
-      { :smartypants => :smart,
-        :escape_html => :markdown_strict
-      }
+      { :smartypants => :smart }
     end
 
     def options_array

--- a/test/tilt_markdown_test.rb
+++ b/test/tilt_markdown_test.rb
@@ -180,10 +180,14 @@ begin
   class MarkdownPandocTest < Minitest::Test
     include MarkdownTests
     template Tilt::PandocTemplate
-    # Doesn't support escaping
+
+    # undef test_escape_html
+    undef test_escape_html_false
     undef test_escape_html_true
-    # Smarty Pants is *always* on, but doesn't support it fully
-    undef test_smarty_pants
+    # undef test_smart_quotes
+    undef test_smart_quotes_false
+    undef test_smart_quotes_true
+    # undef test_smarty_pants
     undef test_smarty_pants_false
   end
 rescue LoadError => boom

--- a/test/tilt_markdown_test.rb
+++ b/test/tilt_markdown_test.rb
@@ -174,4 +174,18 @@ rescue LoadError
   warn "Markdown tests need Nokogiri"
 end
 
+begin
+  require 'tilt/pandoc'
 
+  class MarkdownPandocTest < Minitest::Test
+    include MarkdownTests
+    template Tilt::PandocTemplate
+    # Doesn't support escaping
+    undef test_escape_html_true
+    # Smarty Pants is *always* on, but doesn't support it fully
+    undef test_smarty_pants
+    undef test_smarty_pants_false
+  end
+rescue LoadError => boom
+  # It should already be warned in the main tests
+end

--- a/test/tilt_markdown_test.rb
+++ b/test/tilt_markdown_test.rb
@@ -181,14 +181,8 @@ begin
     include MarkdownTests
     template Tilt::PandocTemplate
 
-    # undef test_escape_html
-    undef test_escape_html_false
+    # Doesn't support escaping
     undef test_escape_html_true
-    # undef test_smart_quotes
-    undef test_smart_quotes_false
-    undef test_smart_quotes_true
-    # undef test_smarty_pants
-    undef test_smarty_pants_false
   end
 rescue LoadError => boom
   # It should already be warned in the main tests

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -9,27 +9,28 @@ begin
       %w[md mkd markdown].each do |ext|
         lazy = Tilt.lazy_map[ext]
         kram_idx = lazy.index { |klass, file| klass == 'Tilt::KramdownTemplate' }
-        maru_idx = lazy.index { |klass, file| klass == 'Tilt::PandocTemplate' }
-        assert maru_idx > kram_idx,
-          "#{maru_idx} should be higher than #{kram_idx}"
+        pandoc_idx = lazy.index { |klass, file| klass == 'Tilt::PandocTemplate' }
+        assert pandoc_idx > kram_idx,
+          "#{pandoc_idx} should be higher than #{kram_idx}"
       end
     end
 
     test "preparing and evaluating templates on #render" do
       template = Tilt::PandocTemplate.new { |t| "# Hello World!" }
-      assert_equal "<h1 id=\"hello_world\">Hello World!</h1>", template.render.strip
+      assert_equal "<h1 id=\"hello-world\">Hello World!</h1>", template.render.strip
     end
 
     test "can be rendered more than once" do
       template = Tilt::PandocTemplate.new { |t| "# Hello World!" }
-      3.times { assert_equal "<h1 id=\"hello_world\">Hello World!</h1>", template.render.strip }
+      3.times { assert_equal "<h1 id=\"hello-world\">Hello World!</h1>", template.render.strip }
     end
 
-    test "removes HTML when :filter_html is set" do
-      template = Tilt::PandocTemplate.new(:filter_html => true) { |t|
-        "HELLO <blink>WORLD</blink>" }
-      assert_equal "<p>HELLO</p>", template.render.strip
+    test "generates footnotes" do
+      template = Tilt::PandocTemplate.new { |t| "Here is an inline note.^[Inlines notes are cool!]" }
+      assert_equal "<p>Here is an inline note.<a href=\"#fn1\" class=\"footnoteRef\" id=\"fnref1\"><sup>1</sup></a></p>\n<div class=\"footnotes\">\n<hr />\n<ol>\n<li id=\"fn1\"><p>Inlines notes are cool!<a href=\"#fnref1\">↩</a></p></li>\n</ol>\n</div>", template.render.strip
     end
+
+    test "passes in Pandoc options"
   end
 rescue LoadError => boom
   warn "Tilt::PandocTemplate (disabled)"

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -20,8 +20,13 @@ begin
       assert_equal "<p>OKAY – ‘Smarty Pants’</p>", template.render
     end
 
-    # Pandoc has tons of additional markdown features.
-    # The test for footnotes should be see as a general representation for all of them.
+    test "stripping HTML when :escape_html is set" do
+      template = Tilt::PandocTemplate.new(:escape_html => true) { |t| "HELLO <blink>WORLD</blink>" }
+      assert_equal "<p>HELLO &lt;blink&gt;WORLD&lt;/blink&gt;</p>", template.render
+    end
+
+    # Pandoc has tons of additional markdown features (see http://pandoc.org/README.html#pandocs-markdown).
+    # The test for footnotes should be seen as a general representation for all of them.
     test "generates footnotes" do
       template = Tilt::PandocTemplate.new { |t| "Here is an inline note.^[Inlines notes are cool!]" }
       assert_equal "<p>Here is an inline note.<a href=\"#fn1\" class=\"footnoteRef\" id=\"fnref1\"><sup>1</sup></a></p>\n<div class=\"footnotes\">\n<hr />\n<ol>\n<li id=\"fn1\"><p>Inlines notes are cool!<a href=\"#fnref1\">↩</a></p></li>\n</ol>\n</div>", template.render.strip

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -5,16 +5,6 @@ begin
   require 'tilt/pandoc'
 
   class PandocTemplateTest < Minitest::Test
-    test "registered below Kramdown" do
-      %w[md mkd markdown].each do |ext|
-        lazy = Tilt.lazy_map[ext]
-        kram_idx = lazy.index { |klass, file| klass == 'Tilt::KramdownTemplate' }
-        pandoc_idx = lazy.index { |klass, file| klass == 'Tilt::PandocTemplate' }
-        assert pandoc_idx > kram_idx,
-          "#{pandoc_idx} should be higher than #{kram_idx}"
-      end
-    end
-
     test "preparing and evaluating templates on #render" do
       template = Tilt::PandocTemplate.new { |t| "# Hello World!" }
       assert_equal "<h1 id=\"hello-world\">Hello World!</h1>", template.render.strip

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -38,7 +38,7 @@ begin
     end
 
     describe "passing in Pandoc options" do
-      test "accepts arguments with values" do
+      test "accepts arguments with values (e.g. :id_prefix => 'xyz')" do
         # Table of contents isn't on by default
         template = Tilt::PandocTemplate.new { |t| "# This is a heading" }
         assert_equal "<h1 id=\"this-is-a-heading\">This is a heading</h1>", template.render
@@ -48,8 +48,7 @@ begin
         assert_equal "<h1 id=\"test-this-is-a-heading\">This is a heading</h1>", template.render
       end
 
-      # Arguments without value (e.g. --standalone) need to be passed as hash keys, too (simply set them to true)
-      test "requires arguments without value as true values" do
+      test "requires arguments without value (e.g. --standalone) to be passed as hash keys (:standalone => true)" do
         template = Tilt::PandocTemplate.new(:standalone => true) { |t| "# This is a heading" }
         assert_match /^<!DOCTYPE html.*<h1 id="this-is-a-heading">This is a heading<\/h1>.*<\/html>$/m, template.render
       end

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'tilt'
 
 begin
-  require 'tilt/maruku'
+  require 'tilt/pandoc'
 
   class PandocTemplateTest < Minitest::Test
     test "registered below Kramdown" do
@@ -25,13 +25,40 @@ begin
       3.times { assert_equal "<h1 id=\"hello-world\">Hello World!</h1>", template.render.strip }
     end
 
+    test "smartypants when :smartypants is set" do
+      template = Tilt::PandocTemplate.new(:smartypants => true) { |t| "OKAY -- 'Smarty Pants'" }
+      assert_equal "<p>OKAY – ‘Smarty Pants’</p>", template.render
+    end
+
+    test "stripping HTML when :escape_html is set" do
+      skip "Couldn't find appropriate option for Pandoc, see http://stackoverflow.com/questions/37165374/pandoc-escape-html-option"
+      template = Tilt::PandocTemplate.new(:escape_html => true) { |t| "HELLO <blink>WORLD</blink>" }
+      assert_equal "<p>HELLO &lt;blink>WORLD&lt;/blink></p>", template.render
+    end
+
+    # Pandoc has tons of additional markdown features.
+    # The test for footnotes should be see as a general representation for all of them.
     test "generates footnotes" do
       template = Tilt::PandocTemplate.new { |t| "Here is an inline note.^[Inlines notes are cool!]" }
       assert_equal "<p>Here is an inline note.<a href=\"#fn1\" class=\"footnoteRef\" id=\"fnref1\"><sup>1</sup></a></p>\n<div class=\"footnotes\">\n<hr />\n<ol>\n<li id=\"fn1\"><p>Inlines notes are cool!<a href=\"#fnref1\">↩</a></p></li>\n</ol>\n</div>", template.render.strip
     end
 
-    test "passes in Pandoc options" do
-      # TODO
+    describe "passing in Pandoc options" do
+      test "accepts arguments with values" do
+        # Table of contents isn't on by default
+        template = Tilt::PandocTemplate.new { |t| "# This is a heading" }
+        assert_equal "<h1 id=\"this-is-a-heading\">This is a heading</h1>", template.render
+
+        # But it can be activated
+        template = Tilt::PandocTemplate.new(id_prefix: 'test-') { |t| "# This is a heading" }
+        assert_equal "<h1 id=\"test-this-is-a-heading\">This is a heading</h1>", template.render
+      end
+
+      # Arguments without value (e.g. --standalone) need to be passed as hash keys, too (simply set them to true)
+      test "requires arguments without value as true values" do
+        template = Tilt::PandocTemplate.new(standalone: true) { |t| "# This is a heading" }
+        assert_match /^<!DOCTYPE html.*<h1 id="this-is-a-heading">This is a heading<\/h1>.*<\/html>$/m, template.render
+      end
     end
   end
 rescue LoadError => boom

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'test_helper'
 require 'tilt'
 

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'tilt'
+
+begin
+  require 'tilt/maruku'
+
+  class PandocTemplateTest < Minitest::Test
+    test "registered below Kramdown" do
+      %w[md mkd markdown].each do |ext|
+        lazy = Tilt.lazy_map[ext]
+        kram_idx = lazy.index { |klass, file| klass == 'Tilt::KramdownTemplate' }
+        maru_idx = lazy.index { |klass, file| klass == 'Tilt::PandocTemplate' }
+        assert maru_idx > kram_idx,
+          "#{maru_idx} should be higher than #{kram_idx}"
+      end
+    end
+
+    test "preparing and evaluating templates on #render" do
+      template = Tilt::PandocTemplate.new { |t| "# Hello World!" }
+      assert_equal "<h1 id=\"hello_world\">Hello World!</h1>", template.render.strip
+    end
+
+    test "can be rendered more than once" do
+      template = Tilt::PandocTemplate.new { |t| "# Hello World!" }
+      3.times { assert_equal "<h1 id=\"hello_world\">Hello World!</h1>", template.render.strip }
+    end
+
+    test "removes HTML when :filter_html is set" do
+      template = Tilt::PandocTemplate.new(:filter_html => true) { |t|
+        "HELLO <blink>WORLD</blink>" }
+      assert_equal "<p>HELLO</p>", template.render.strip
+    end
+  end
+rescue LoadError => boom
+  warn "Tilt::PandocTemplate (disabled)"
+end

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -50,13 +50,13 @@ begin
         assert_equal "<h1 id=\"this-is-a-heading\">This is a heading</h1>", template.render
 
         # But it can be activated
-        template = Tilt::PandocTemplate.new(id_prefix: 'test-') { |t| "# This is a heading" }
+        template = Tilt::PandocTemplate.new(:id_prefix => 'test-') { |t| "# This is a heading" }
         assert_equal "<h1 id=\"test-this-is-a-heading\">This is a heading</h1>", template.render
       end
 
       # Arguments without value (e.g. --standalone) need to be passed as hash keys, too (simply set them to true)
       test "requires arguments without value as true values" do
-        template = Tilt::PandocTemplate.new(standalone: true) { |t| "# This is a heading" }
+        template = Tilt::PandocTemplate.new(:standalone => true) { |t| "# This is a heading" }
         assert_match /^<!DOCTYPE html.*<h1 id="this-is-a-heading">This is a heading<\/h1>.*<\/html>$/m, template.render
       end
     end

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -30,12 +30,6 @@ begin
       assert_equal "<p>OKAY – ‘Smarty Pants’</p>", template.render
     end
 
-    test "stripping HTML when :escape_html is set" do
-      skip "Couldn't find appropriate option for Pandoc, see http://stackoverflow.com/questions/37165374/pandoc-escape-html-option"
-      template = Tilt::PandocTemplate.new(:escape_html => true) { |t| "HELLO <blink>WORLD</blink>" }
-      assert_equal "<p>HELLO &lt;blink>WORLD&lt;/blink></p>", template.render
-    end
-
     # Pandoc has tons of additional markdown features.
     # The test for footnotes should be see as a general representation for all of them.
     test "generates footnotes" do

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -30,7 +30,9 @@ begin
       assert_equal "<p>Here is an inline note.<a href=\"#fn1\" class=\"footnoteRef\" id=\"fnref1\"><sup>1</sup></a></p>\n<div class=\"footnotes\">\n<hr />\n<ol>\n<li id=\"fn1\"><p>Inlines notes are cool!<a href=\"#fnref1\">↩</a></p></li>\n</ol>\n</div>", template.render.strip
     end
 
-    test "passes in Pandoc options"
+    test "passes in Pandoc options" do
+      # TODO
+    end
   end
 rescue LoadError => boom
   warn "Tilt::PandocTemplate (disabled)"


### PR DESCRIPTION
I need Pandoc in my Rails project. This is my attempt to register Pandoc as markdown parser in Tilt.

Any improvements are very welcome.

Here's the original question which made me create this PR: [Slim template: use Pandoc as markdown converter?](http://stackoverflow.com/questions/30058230/slim-template-use-pandoc-as-markdown-converter)

The tests aren't all passing yet. In fact, I'm a bit unsure on how to proceed, because of the following questions:

- As the used `pandoc-ruby` gem is only a wrapper for the `$ pandoc` command line tool, I'm unsure whether somehow it should be checked whether pandoc is installed on the system or not. Maybe `pandoc-ruby` does this already?
- Pandoc has a huge amount of special features. For examples, I love the [footnotes](http://pandoc.org/README.html#footnotes). Should some of these things be tested, too? I'm asking because I see there are some tests verifying that e.g. escaping HTML works ([`test_escape_html_true`](https://github.com/rtomayko/tilt/blob/master/test/tilt_markdown_test.rb#L31)).
- Some of the features are called a bit different in Pandoc: for example, the `:smartypants` option is only `:smart`.
    - Should I simply undef the default test?
    - Should I add a mechanism in `PandocTemplate` that converts the `:smartypants` option into `:smart`?