### PR TITLE
Removed changing constant lookup scope in compiled templates.

### DIFF
--- a/test/tilt_stringtemplate_test.rb
+++ b/test/tilt_stringtemplate_test.rb
@@ -49,6 +49,7 @@ class StringTemplateTest < Minitest::Test
       fail 'should have raised an exception'
     rescue => boom
       assert_kind_of NameError, boom
+      assert_equal 1, boom.backtrace.count { |x| x['test.str'] }
       line = boom.backtrace.grep(/^test\.str:/).first
       assert line, "Backtrace didn't contain test.str"
       file, line, meth = line.split(":")

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -189,7 +189,7 @@ class TiltTemplateTest < Minitest::Test
   end
 
   test "template which accesses a constant" do
-    inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{CONSTANT}!' }
+    inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{self.class::CONSTANT}!' }
     assert_equal "Hey Bob!", inst.render(Person.new("Joe"))
   end
 


### PR DESCRIPTION
It singificantly simplifies code and removes extra lines with
wrong source locations from backtrace.

Without this commit backtrace is:
```
test.str:13:in `block in singleton class'
test.str:7:in `instance_eval'
test.str:7:in `singleton class'
test.str:5:in `__tilt_70221264454100'
.../tilt/lib/tilt/template.rb:165:in `call'
...
```

After:
```
test.str:13:in `__tilt_70182127403480'
.../tilt/lib/tilt/template.rb:165:in `call'
```

It's especially confusing when used with real files, because locations point to other source.
This can also be avoided by using `method_source.lines.map(&:strip).join('; ')` to concat lines. But I think it's not a big problem to use `self.class::CONST` instead of just `COST` even explicit constant lookup.