### PR TITLE
Filter options for pandoc

### DIFF
--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -11,7 +11,7 @@ module Tilt
     UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks]
 
     # some options are passed via variable parameter
-    VARIABLE_OPTIONS = [:lang]
+    VARIABLE_OPTIONS = [:lang, :locale]
 
     def tilt_to_pandoc_mapping
       { :smartypants => :smart,

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -8,7 +8,10 @@ module Tilt
     self.default_mime_type = 'text/html'
 
     # some options are not recognized by Pandoc
-    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks, :lang, :locale]
+    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks]
+
+    # some options are passed via variable parameter
+    VARIABLE_OPTIONS = [:lang]
 
     def tilt_to_pandoc_mapping
       { :smartypants => :smart,
@@ -34,7 +37,11 @@ module Tilt
         when false
           sum
         else
-          sum << { k => v }
+          if VARIABLE_OPTIONS.include?(k)
+            sum << { "variable" => "#{k}:#{v}" }
+          else
+            sum << { k => v }
+          end
         end
       end
     end

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -8,7 +8,7 @@ module Tilt
     self.default_mime_type = 'text/html'
 
     # some options are not recognized by Pandoc
-    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks, :lang, :locale]
+    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks, :locale]
 
     def tilt_to_pandoc_mapping
       { :smartypants => :smart,

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -8,7 +8,7 @@ module Tilt
     self.default_mime_type = 'text/html'
 
     # some options are not recognized by Pandoc
-    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks]
+    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks, :keep_separator]
 
     # some options are passed via variable parameter
     VARIABLE_OPTIONS = [:lang, :locale]

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -8,7 +8,7 @@ module Tilt
     self.default_mime_type = 'text/html'
 
     # some options are not recognized by Pandoc
-    UNRECOGNIZED_OPTIONS = [:outvar, :context]
+    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks]
 
     def tilt_to_pandoc_mapping
       { :smartypants => :smart,

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -8,7 +8,7 @@ module Tilt
     self.default_mime_type = 'text/html'
 
     # some options are not recognized by Pandoc
-    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks]
+    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks, :lang, :locale]
 
     def tilt_to_pandoc_mapping
       { :smartypants => :smart,

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -7,6 +7,9 @@ module Tilt
   class PandocTemplate < Template
     self.default_mime_type = 'text/html'
 
+    # some options are not recognized by Pandoc
+    UNRECOGNIZED_OPTIONS = [:outvar, :context]
+
     def tilt_to_pandoc_mapping
       { :smartypants => :smart,
         :escape_html => { :f => 'markdown-raw_html' },
@@ -19,9 +22,12 @@ module Tilt
     # Map tilt options to pandoc options
     # Replace hash keys with value true with symbol for key
     # Remove hash keys with value false
+    # Remove unrecognized keys
     # Leave other hash keys untouched
     def pandoc_options
       options.reduce([]) do |sum, (k,v)|
+        return sum if UNRECOGNIZED_OPTIONS.include?(k)
+
         case v
         when true
           sum << (tilt_to_pandoc_mapping[k] || k)
@@ -45,5 +51,6 @@ module Tilt
     def allows_script?
       false
     end
+end
   end
 end

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -8,7 +8,7 @@ module Tilt
     self.default_mime_type = 'text/html'
 
     # some options are not recognized by Pandoc
-    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks, :locale]
+    UNRECOGNIZED_OPTIONS = [:outvar, :context, :fenced_code_blocks, :lang, :locale]
 
     def tilt_to_pandoc_mapping
       { :smartypants => :smart,

--- a/lib/tilt/pandoc.rb
+++ b/lib/tilt/pandoc.rb
@@ -51,6 +51,5 @@ module Tilt
     def allows_script?
       false
     end
-end
   end
 end

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -66,6 +66,12 @@ begin
         template = Tilt::PandocTemplate.new(:context => true) { |t| "# This is a heading" }
         assert_equal "<h1 id=\"this-is-a-heading\">This is a heading</h1>", template.render
       end
+
+      # some options need to be passed via --variable
+      test "support variable options" do
+        template = Tilt::PandocTemplate.new(:lang => "en") { |t| "# This is a heading" }
+        assert_equal "<h1 id=\"this-is-a-heading\">This is a heading</h1>", template.render
+      end
     end
   end
 rescue LoadError => boom

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -60,6 +60,12 @@ begin
         template = Tilt::PandocTemplate.new(:standalone => true) { |t| "# This is a heading" }
         assert_match /^<!DOCTYPE html.*<h1 id="this-is-a-heading">This is a heading<\/h1>.*<\/html>$/m, template.render
       end
+
+      # pandoc-ruby can't handle some middleman options
+      test "ignore unsupported options" do
+        template = Tilt::PandocTemplate.new(:context => true) { |t| "# This is a heading" }
+        assert_equal "<h1 id=\"this-is-a-heading\">This is a heading</h1>", template.render
+      end
     end
   end
 rescue LoadError => boom


### PR DESCRIPTION
`Pandoc-ruby` throws an error if an option is not recognized, including the middleman options `:outvar`, `:context` and `:fenced_code_blocks`. We should filter them out before passing the options on to `pandoc-ruby`.

Because Pandoc has so many configuration options, this approach might be more pragmatic then a whitelist approach. 

With this pull-request (and imminent changes in middleman to support Tilt 2) we can use Pandoc as markdown parser in `middleman`.
