### PR TITLE
Add Liquid options tests

### DIFF
--- a/lib/tilt/liquid.rb
+++ b/lib/tilt/liquid.rb
@@ -34,11 +34,11 @@ module Tilt
     def allows_script?
       false
     end
-    
+
     private
-    
+
     def liquid_options
-      options.merge(line_numbers: true)
+      { line_numbers: true }.merge options
     end
   end
 end

--- a/test/tilt_liquidtemplate_test.rb
+++ b/test/tilt_liquidtemplate_test.rb
@@ -24,6 +24,15 @@ begin
       assert_equal "Hey Joe!", template.render(nil, :name => 'Joe')
     end
 
+    test "options can be set" do
+      err = assert_raises(Liquid::SyntaxError) do
+        options = { line_numbers: false, error_mode: :strict }
+        Tilt::LiquidTemplate.new(options) { "{{%%%}}" }.render
+      end
+      assert_equal 'Liquid syntax error: Unexpected character % in "{{%%%}}"',
+        err.message
+    end
+
     # Object's passed as "scope" to LiquidTemplate may respond to
     # #to_h with a Hash. The Hash's contents are merged underneath
     # Tilt locals.


### PR DESCRIPTION
Ref #298 - Adds a test for overwriting default Liquid options/passing other options.

**Note:** Travis build failed due to RubyGems.org downtime