### PR TITLE
Tilt 2.0.2 and later no longer looks for .md files when redcarpet is used

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -123,7 +123,8 @@ module Tilt
   register_lazy :MarukuTemplate,       'tilt/maruku',       'markdown', 'mkd', 'md'
   register_lazy :KramdownTemplate,     'tilt/kramdown',     'markdown', 'mkd', 'md'
   register_lazy :RDiscountTemplate,    'tilt/rdiscount',    'markdown', 'mkd', 'md'
-  register_lazy :RedcarpetTemplate,    'tilt/redcarpet',    'markdown', 'mkd', 'md'
+  register_lazy :Redcarpet1Template,    'tilt/redcarpet',    'markdown', 'mkd', 'md'
+  register_lazy :Redcarpet2Template,    'tilt/redcarpet',    'markdown', 'mkd', 'md'
   register_lazy :CommonMarkerTemplate, 'tilt/commonmarker', 'markdown', 'mkd', 'md'
   register_lazy :PandocTemplate,       'tilt/pandoc',       'markdown', 'mkd', 'md'
 


### PR DESCRIPTION
I'm using `markdown :somefile` from haml, which with tilt 2.0.1 will find a file named "somefile.md" but which with tilt 2.0.2 and later will try only "somefile.markdown" and fail.  This is because there's a call to register_lazy which is still using the obsolete name :RedcarpetTemplate when it needs to use :Redcarpet1Template and :Redcarpet2Template.

There is a variable Tilt::RedcarpetTemplate which is set to the class to use, but it's not yet set when register_lazy is called, so this patch just registers both, easy.

Sorry no test because I don't really understand enough of what's going on here to even know whether I made a good fix.
