### PR TITLE
Add Tilt::Template#freeze_string_literals?

### DIFF
--- a/lib/tilt/erb.rb
+++ b/lib/tilt/erb.rb
@@ -19,6 +19,7 @@ module Tilt
     end
 
     def prepare
+      @freeze_string_literals = !!@options[:freeze]
       @outvar = options[:outvar] || self.class.default_output_variable
       trim = case options[:trim]
       when false
@@ -62,6 +63,10 @@ module Tilt
     def precompiled(locals)
       source, offset = super
       [source, offset + 1]
+    end
+
+    def freeze_string_literals?
+      @freeze_string_literals
     end
   end
 end

--- a/lib/tilt/erubi.rb
+++ b/lib/tilt/erubi.rb
@@ -16,6 +16,24 @@ module Tilt
 
       engine_class = @options[:engine_class] || Erubi::Engine
 
+      # If :freeze option is given, the intent is to setup frozen string
+      # literals in the template.  So enable frozen string literals in the
+      # code Tilt generates if the :freeze option is given.
+      if @freeze_string_literals = !!@options[:freeze]
+        # Passing the :freeze option to Erubi sets the
+        # frozen-string-literal magic comment, which doesn't have an effect
+        # with Tilt as Tilt wraps the resulting code.  Worse, the magic
+        # comment appearing not at the top of the file can cause a warning.
+        # So remove the :freeze option before passing to Erubi.
+        @options.delete(:freeze)
+
+        # Erubi by default appends .freeze to template literals on Ruby 2.1+,
+        # but that is not necessary and slows down code when Tilt is using
+        # frozen string literals, so pass the :freeze_template_literals
+        # option to not append .freeze.
+        @options[:freeze_template_literals] = false
+      end
+
       @engine = engine_class.new(data, @options)
       @outvar = @engine.bufvar
 
@@ -27,6 +45,10 @@ module Tilt
 
     def precompiled_template(locals)
       @src
+    end
+
+    def freeze_string_literals?
+      @freeze_string_literals
     end
   end
 end

--- a/lib/tilt/erubis.rb
+++ b/lib/tilt/erubis.rb
@@ -16,6 +16,7 @@ module Tilt
   #                   within <%= %> blocks will be automatically html escaped.
   class ErubisTemplate < ERBTemplate
     def prepare
+      @freeze_string_literals = !!@options.delete(:freeze)
       @outvar = options.delete(:outvar) || self.class.default_output_variable
       @options.merge!(:preamble => false, :postamble => false, :bufvar => @outvar)
       engine_class = options.delete(:engine_class)
@@ -36,6 +37,10 @@ module Tilt
     def precompiled(locals)
       source, offset = super
       [source, offset - 1]
+    end
+
+    def freeze_string_literals?
+      @freeze_string_literals
     end
   end
 end

--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -276,8 +276,13 @@ module Tilt
         method_source.force_encoding(source.encoding)
       end
 
+      if freeze_string_literals?
+        method_source << "# frozen-string-literal: true\n"
+      end
+
       # Don't indent method source, to avoid indentation warnings when using compiled paths
       method_source << "::Tilt::TOPOBJECT.class_eval do\ndef #{method_name}(locals)\n#{local_code}\n"
+
       offset += method_source.count("\n")
       method_source << source
       method_source << "\nend;end;"
@@ -337,6 +342,10 @@ module Tilt
       binary(script) do
         script[/\A[ \t]*\#.*coding\s*[=:]\s*([[:alnum:]\-_]+).*$/n, 1]
       end
+    end
+
+    def freeze_string_literals?
+      false
     end
 
     def binary(string)

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -225,6 +225,13 @@ describe 'tilt/erb (compiled)' do
     3.times { assert_equal 'UTF-8', erb.render(self).encoding.to_s }
     f.delete
   end
+
+  if RUBY_VERSION >= '2.3'
+    it "uses frozen literal strings if :freeze option is used" do
+      template = Tilt::ERBTemplate.new(nil, :freeze => true) { |t| %(<%= "".frozen? %>) }
+      assert_equal "true", template.render
+    end
+  end
 end
 
 __END__

--- a/test/tilt_erubistemplate_test.rb
+++ b/test/tilt_erubistemplate_test.rb
@@ -138,6 +138,13 @@ begin
       Tilt::ErubisTemplate.new(nil, options_hash) { |t| "Hello World!" }
       assert_equal({:escape_html => true}, options_hash)
     end
+
+    if RUBY_VERSION >= '2.3'
+      it "uses frozen literal strings if :freeze option is used" do
+        template = Tilt::ErubisTemplate.new(nil, :freeze => true) { |t| %(<%= "".frozen? %>) }
+        assert_equal "true", template.render
+      end
+    end
   end
 rescue LoadError
   warn "Tilt::ErubisTemplate (disabled)"

--- a/test/tilt_erubitemplate_test.rb
+++ b/test/tilt_erubitemplate_test.rb
@@ -141,6 +141,13 @@ begin
       Tilt::ErubiTemplate.new(nil, options_hash) { |t| "Hello World!" }
       assert_equal({:escape_html => true}, options_hash)
     end
+
+    if RUBY_VERSION >= '2.3'
+      it "uses frozen literal strings if :freeze option is used" do
+        template = Tilt::ErubiTemplate.new(nil, :freeze => true) { |t| %(<%= "".frozen? %>) }
+        assert_equal "true", template.render
+      end
+    end
   end
 rescue LoadError
   warn "Tilt::ErubiTemplate (disabled)"

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -311,8 +311,28 @@ describe "tilt/template" do
     assert_equal inst2, $inst2
     assert_nil Tilt.current_template
   end
+
+  if RUBY_VERSION >= '2.3'
+    _FrozenStringMockTemplate = Class.new(_PreparingMockTemplate) do
+      def freeze_string_literals?
+        true
+      end
+      def precompiled_template(locals)
+        "'bar'"
+      end
+    end
+
+    it "uses frozen literal strings if freeze_literal_strings? is true" do
+      inst = _FrozenStringMockTemplate.new{|d| 'a'}
+      assert_equal "bar", inst.render
+      assert_equal true, inst.render.frozen?
+      assert inst.prepared?
+    end
+  end
 end
 
+  ##
+  # Encodings
 describe "tilt/template (encoding)" do
   _DynamicMockTemplate = Class.new(_MockTemplate) do
     def precompiled_template(locals)


### PR DESCRIPTION
If this returns true, frozen-string-literal: true is set when
compiling the template method.  It is false by default, and
will need to be manually set to true in the template classes
that could support it.