### PR TITLE
Suppress "assigned but unused variable - locals" warning

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -261,6 +261,7 @@ module Tilt
             Thread.current[:tilt_vars] = [self, locals]
             class << self
               this, locals = Thread.current[:tilt_vars]
+              locals = locals
               this.instance_eval do
                 #{local_code}
       RUBY


### PR DESCRIPTION
Without this dirty hack, ruby emits "assigned but unused variable - locals" warning in VERBOSE mode when no locals are given.

Following is a oneliner that reproduces the warning:
```
% ruby -rtilt -we "Tilt::ERBTemplate.new('test.erb', 11) { '' }.render"
test.erb:3: warning: assigned but unused variable - locals
```