### PR TITLE
Ruby warnings in the tests

### DIFF
--- a/test/tilt_asciidoctor_test.rb
+++ b/test/tilt_asciidoctor_test.rb
@@ -45,6 +45,6 @@ begin
       3.times { assert_equal HTML5_OUTPUT, strip_space(template.render) }
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::AsciidoctorTemplate (disabled)"
 end

--- a/test/tilt_blueclothtemplate_test.rb
+++ b/test/tilt_blueclothtemplate_test.rb
@@ -28,6 +28,6 @@ begin
       assert_equal "<p>HELLO &lt;blink>WORLD&lt;/blink></p>", template.render
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::BlueClothTemplate (disabled)"
 end

--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -30,7 +30,7 @@ begin
           refute_match "(function() {", template.render
           assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello, \" + name);\n", template.render
 
-          template2 = @renderer.new(:no_wrap => true) { @code_with_variables}
+          template = @renderer.new(:no_wrap => true) { @code_with_variables}
           refute_match "(function() {", template.render
           assert_equal "var name;\n\nname = \"Josh\";\n\nputs(\"Hello, \" + name);\n", template.render
         end

--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -136,6 +136,6 @@ EOLIT
     end
   end
 
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::CoffeeScriptTemplate (disabled)"
 end

--- a/test/tilt_commonmarkertemplate_test.rb
+++ b/test/tilt_commonmarkertemplate_test.rb
@@ -15,6 +15,6 @@ begin
       3.times { assert_equal "<h1>Hello World!</h1>\n", template.render }
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::CommonMarkerTemplate (disabled)"
 end

--- a/test/tilt_creoletemplate_test.rb
+++ b/test/tilt_creoletemplate_test.rb
@@ -19,6 +19,6 @@ begin
       3.times { assert_equal "<h1>Hello World!</h1>", template.render }
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::CreoleTemplate (disabled)"
 end

--- a/test/tilt_csv_test.rb
+++ b/test/tilt_csv_test.rb
@@ -61,7 +61,7 @@ begin
     end
   end
 
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::CSVTemplate (disabled) please install 'fastercsv' if using ruby 1.8.x"
 end
 

--- a/test/tilt_csv_test.rb
+++ b/test/tilt_csv_test.rb
@@ -42,7 +42,7 @@ begin
         assert_kind_of NameError, boom
         line = boom.backtrace.grep(/^test\.csv:/).first
         assert line, "Backtrace didn't contain test.csv"
-        file, line, meth = line.split(":")
+        _file, line, _meth = line.split(":")
         assert_equal '4', line
       end
     end

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -68,7 +68,7 @@ class ERBTemplateTest < Minitest::Test
       assert_kind_of NameError, boom
       line = boom.backtrace.grep(/^test\.erb:/).first
       assert line, "Backtrace didn't contain test.erb"
-      file, line, meth = line.split(":")
+      _file, line, _meth = line.split(":")
       assert_equal '13', line
     end
   end
@@ -83,7 +83,7 @@ class ERBTemplateTest < Minitest::Test
     rescue => boom
       assert_kind_of RuntimeError, boom
       line = boom.backtrace.first
-      file, line, meth = line.split(":")
+      file, line, _meth = line.split(":")
       assert_equal 'test.erb', file
       assert_equal '6', line
     end
@@ -170,7 +170,7 @@ class CompiledERBTemplateTest < Minitest::Test
       assert_kind_of NameError, boom
       line = boom.backtrace.grep(/^test\.erb:/).first
       assert line, "Backtrace didn't contain test.erb"
-      file, line, meth = line.split(":")
+      _file, line, _meth = line.split(":")
       assert_equal '13', line
     end
   end
@@ -185,7 +185,7 @@ class CompiledERBTemplateTest < Minitest::Test
     rescue => boom
       assert_kind_of RuntimeError, boom
       line = boom.backtrace.first
-      file, line, meth = line.split(":")
+      file, line, _meth = line.split(":")
       assert_equal 'test.erb', file
       assert_equal '6', line
     end

--- a/test/tilt_erubistemplate_test.rb
+++ b/test/tilt_erubistemplate_test.rb
@@ -136,7 +136,7 @@ begin
       assert_equal({:escape_html => true}, options_hash)
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::ErubisTemplate (disabled)"
 end
 

--- a/test/tilt_erubistemplate_test.rb
+++ b/test/tilt_erubistemplate_test.rb
@@ -74,7 +74,7 @@ begin
         assert_kind_of NameError, boom
         line = boom.backtrace.grep(/^test\.erubis:/).first
         assert line, "Backtrace didn't contain test.erubis"
-        file, line, meth = line.split(":")
+        _file, line, _meth = line.split(":")
         assert_equal '13', line
       end
     end
@@ -89,7 +89,7 @@ begin
       rescue => boom
         assert_kind_of RuntimeError, boom
         line = boom.backtrace.first
-        file, line, meth = line.split(":")
+        file, line, _meth = line.split(":")
         assert_equal 'test.erubis', file
         assert_equal '6', line
       end

--- a/test/tilt_erubistemplate_test.rb
+++ b/test/tilt_erubistemplate_test.rb
@@ -132,7 +132,7 @@ begin
 
     test "does not modify options argument" do
       options_hash = {:escape_html => true}
-      template = Tilt::ErubisTemplate.new(nil, options_hash) { |t| "Hello World!" }
+      Tilt::ErubisTemplate.new(nil, options_hash) { |t| "Hello World!" }
       assert_equal({:escape_html => true}, options_hash)
     end
   end

--- a/test/tilt_etannitemplate_test.rb
+++ b/test/tilt_etannitemplate_test.rb
@@ -55,7 +55,7 @@ class EtanniTemplateTest < Minitest::Test
       assert_kind_of NameError, boom
       line = boom.backtrace.grep(/^test\.etn:/).first
       assert line, "Backtrace didn't contain test.etn"
-      file, line, meth = line.split(":")
+      _file, line, _meth = line.split(":")
       assert_equal '13', line
     end
   end
@@ -70,7 +70,7 @@ class EtanniTemplateTest < Minitest::Test
     rescue => boom
       assert_kind_of RuntimeError, boom
       line = boom.backtrace.first
-      file, line, meth = line.split(":")
+      file, line, _meth = line.split(":")
       assert_equal 'test.etn', file
       assert_equal '6', line
     end
@@ -141,7 +141,7 @@ class CompiledEtanniTemplateTest < Minitest::Test
       line = boom.backtrace.first
       line = boom.backtrace.grep(/^test\.etn:/).first
       assert line, "Backtrace didn't contain test.etn"
-      file, line, meth = line.split(":")
+      _file, line, _meth = line.split(":")
       assert_equal '13', line
     end
   end
@@ -156,7 +156,7 @@ class CompiledEtanniTemplateTest < Minitest::Test
     rescue => boom
       assert_kind_of RuntimeError, boom
       line = boom.backtrace.first
-      file, line, meth = line.split(":")
+      file, line, _meth = line.split(":")
       assert_equal 'test.etn', file
       assert_equal '6', line
     end

--- a/test/tilt_hamltemplate_test.rb
+++ b/test/tilt_hamltemplate_test.rb
@@ -71,7 +71,7 @@ begin
       fail unless data[0] == ?%
       template = Tilt::HamlTemplate.new('test.haml') { data }
       begin
-        res = template.render(Object.new, :name => 'Joe', :foo => 'bar')
+        template.render(Object.new, :name => 'Joe', :foo => 'bar')
       rescue => boom
         assert_kind_of MockError, boom
         line = boom.backtrace.first
@@ -142,7 +142,7 @@ begin
       fail unless data[0] == ?%
       template = Tilt::HamlTemplate.new('test.haml') { data }
       begin
-        res = template.render(Scope.new, :name => 'Joe', :foo => 'bar')
+        template.render(Scope.new, :name => 'Joe', :foo => 'bar')
       rescue => boom
         assert_kind_of MockError, boom
         line = boom.backtrace.first

--- a/test/tilt_hamltemplate_test.rb
+++ b/test/tilt_hamltemplate_test.rb
@@ -61,7 +61,7 @@ begin
         assert_kind_of NameError, boom
         line = boom.backtrace.grep(/^test\.haml:/).first
         assert line, "Backtrace didn't contain test.haml"
-        file, line, meth = line.split(":")
+        _file, line, _meth = line.split(":")
         assert_equal '12', line
       end
     end
@@ -75,7 +75,7 @@ begin
       rescue => boom
         assert_kind_of MockError, boom
         line = boom.backtrace.first
-        file, line, meth = line.split(":")
+        file, line, _meth = line.split(":")
         assert_equal 'test.haml', file
         assert_equal '5', line
       end
@@ -132,7 +132,7 @@ begin
         assert_kind_of NameError, boom
         line = boom.backtrace.grep(/^test\.haml:/).first
         assert line, "Backtrace didn't contain test.haml"
-        file, line, meth = line.split(":")
+        _file, line, _meth = line.split(":")
         assert_equal '12', line
       end
     end
@@ -146,7 +146,7 @@ begin
       rescue => boom
         assert_kind_of MockError, boom
         line = boom.backtrace.first
-        file, line, meth = line.split(":")
+        file, line, _meth = line.split(":")
         assert_equal 'test.haml', file
         assert_equal '5', line
       end

--- a/test/tilt_hamltemplate_test.rb
+++ b/test/tilt_hamltemplate_test.rb
@@ -152,7 +152,7 @@ begin
       end
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::HamlTemplate (disabled)"
 end
 

--- a/test/tilt_kramdown_test.rb
+++ b/test/tilt_kramdown_test.rb
@@ -15,6 +15,6 @@ begin
       3.times { assert_equal '<h1 id="hello-world">Hello World!</h1>', template.render.strip }
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::KramdownTemplate (disabled)"
 end

--- a/test/tilt_lesstemplate_test.rb
+++ b/test/tilt_lesstemplate_test.rb
@@ -37,6 +37,6 @@ begin
     end
   end
 
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::LessTemplate (disabled)"
 end

--- a/test/tilt_liquidtemplate_test.rb
+++ b/test/tilt_liquidtemplate_test.rb
@@ -82,6 +82,6 @@ begin
     end
   end
 
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::LiquidTemplate (disabled)"
 end

--- a/test/tilt_livescripttemplate_test.rb
+++ b/test/tilt_livescripttemplate_test.rb
@@ -32,6 +32,6 @@ begin
       assert_equal @renderer, Tilt['test.ls']
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::LiveScriptTemplate (disabled)"
 end

--- a/test/tilt_mapping_test.rb
+++ b/test/tilt_mapping_test.rb
@@ -188,7 +188,7 @@ module Tilt
 
         @mapping.stub :require, req do
           err = assert_raises(LoadError) do
-            klass = @mapping['hello.mt']
+            @mapping['hello.mt']
           end
 
           assert_equal 'my_template2', err.message

--- a/test/tilt_markaby_test.rb
+++ b/test/tilt_markaby_test.rb
@@ -83,6 +83,6 @@ begin
     end
   end
 
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::MarkabyTemplate (disabled)"
 end

--- a/test/tilt_markdown_test.rb
+++ b/test/tilt_markdown_test.rb
@@ -95,7 +95,7 @@ begin
     def test_smarty_pants_true
       # Various versions of Redcarpet support various versions of Smart pants.
       html = nrender "Hello ``World'' -- This is --- a test ...", :smartypants => true
-      assert_match /<p>Hello “World(''|”) – This is — a test …<\/p>/, html
+      assert_match %r!<p>Hello “World(''|”) – This is — a test …<\/p>!, html
     end
 
     def test_renderer_options

--- a/test/tilt_marukutemplate_test.rb
+++ b/test/tilt_marukutemplate_test.rb
@@ -31,6 +31,6 @@ begin
       assert_equal "<p>HELLO</p>", template.render.strip
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::MarukuTemplate (disabled)"
 end

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -58,7 +58,7 @@ begin
 
       test "requires arguments without value (e.g. --standalone) to be passed as hash keys (:standalone => true)" do
         template = Tilt::PandocTemplate.new(:standalone => true) { |t| "# This is a heading" }
-        assert_match /^<!DOCTYPE html.*<h1 id="this-is-a-heading">This is a heading<\/h1>.*<\/html>$/m, template.render
+        assert_match(/^<!DOCTYPE html.*<h1 id="this-is-a-heading">This is a heading<\/h1>.*<\/html>$/m, template.render)
       end
     end
   end

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -62,6 +62,6 @@ begin
       end
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::PandocTemplate (disabled)"
 end

--- a/test/tilt_prawntemplate_test.rb
+++ b/test/tilt_prawntemplate_test.rb
@@ -70,6 +70,6 @@ begin
     
   end
   
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::PrawnTemplate (disabled)"
 end

--- a/test/tilt_radiustemplate_test.rb
+++ b/test/tilt_radiustemplate_test.rb
@@ -69,7 +69,7 @@ begin
     end
   end
 
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::RadiusTemplate (disabled)"
 end
 

--- a/test/tilt_rdiscounttemplate_test.rb
+++ b/test/tilt_rdiscounttemplate_test.rb
@@ -38,6 +38,6 @@ begin
       assert_equal "<p>HELLO &lt;blink>WORLD&lt;/blink></p>\n", template.render
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::RDiscountTemplate (disabled)"
 end

--- a/test/tilt_rdoctemplate_test.rb
+++ b/test/tilt_rdoctemplate_test.rb
@@ -11,16 +11,16 @@ begin
     test "preparing and evaluating the template with #render" do
       template = Tilt::RDocTemplate.new { |t| "= Hello World!" }
       result = template.render.strip
-      assert_match /<h1/, result
-      assert_match />Hello World!</, result
+      assert_match %r(<h1), result
+      assert_match %r(>Hello World!<), result
     end
 
     test "can be rendered more than once" do
       template = Tilt::RDocTemplate.new { |t| "= Hello World!" }
       3.times do
         result = template.render.strip
-        assert_match /<h1/, result
-        assert_match />Hello World!</, result
+        assert_match %r(<h1), result
+        assert_match %r(>Hello World!<), result
       end
     end
   end

--- a/test/tilt_redcarpettemplate_test.rb
+++ b/test/tilt_redcarpettemplate_test.rb
@@ -38,14 +38,14 @@ begin
     test "smartypants when :smart is set" do
       template = Tilt::RedcarpetTemplate.new(:smartypants => true) { |t|
         "OKAY -- 'Smarty Pants'" }
-      assert_match /<p>OKAY &ndash; (&#39;|&lsquo;)Smarty Pants(&#39;|&rsquo;)<\/p>/,
+      assert_match %r!<p>OKAY &ndash; (&#39;|&lsquo;)Smarty Pants(&#39;|&rsquo;)<\/p>!,
         template.render
     end
 
     test "smartypants with a rendererer instance" do
       template = Tilt::RedcarpetTemplate.new(:renderer => Redcarpet::Render::HTML.new(:hard_wrap => true), :smartypants => true) { |t|
         "OKAY -- 'Smarty Pants'" }
-      assert_match /<p>OKAY &ndash; (&#39;|&lsquo;)Smarty Pants(&#39;|&rsquo;)<\/p>/,
+      assert_match %r!<p>OKAY &ndash; (&#39;|&lsquo;)Smarty Pants(&#39;|&rsquo;)<\/p>!,
         template.render
     end
   end

--- a/test/tilt_redcarpettemplate_test.rb
+++ b/test/tilt_redcarpettemplate_test.rb
@@ -49,6 +49,6 @@ begin
         template.render
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::RedcarpetTemplate (disabled)"
 end

--- a/test/tilt_redclothtemplate_test.rb
+++ b/test/tilt_redclothtemplate_test.rb
@@ -31,6 +31,6 @@ begin
       assert_equal "<p>But they can be\nturned off.</p>", template.render
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::RedClothTemplate (disabled)"
 end

--- a/test/tilt_rstpandoctemplate_test.rb
+++ b/test/tilt_rstpandoctemplate_test.rb
@@ -24,7 +24,7 @@ begin
     test "doens't use markdown options" do
       template = Tilt::RstPandocTemplate.new(:escape_html => true) { |t| "HELLO <blink>WORLD</blink>" }
       err = assert_raises(RuntimeError) { template.render }
-      assert_match /pandoc: unrecognized option `--escape-html/, err.message
+      assert_match %r(pandoc: unrecognized option `--escape-html), err.message
     end
   end
 rescue LoadError => boom

--- a/test/tilt_sasstemplate_test.rb
+++ b/test/tilt_sasstemplate_test.rb
@@ -36,6 +36,6 @@ begin
     end
   end
 
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::SassTemplate (disabled)"
 end

--- a/test/tilt_stringtemplate_test.rb
+++ b/test/tilt_stringtemplate_test.rb
@@ -51,7 +51,7 @@ class StringTemplateTest < Minitest::Test
       assert_kind_of NameError, boom
       line = boom.backtrace.grep(/^test\.str:/).first
       assert line, "Backtrace didn't contain test.str"
-      file, line, meth = line.split(":")
+      _file, line, _meth = line.split(":")
       assert_equal '13', line
     end
   end
@@ -66,7 +66,7 @@ class StringTemplateTest < Minitest::Test
     rescue => boom
       assert_kind_of RuntimeError, boom
       line = boom.backtrace.first
-      file, line, meth = line.split(":")
+      file, line, _meth = line.split(":")
       assert_equal 'test.str', file
       assert_equal '6', line
     end
@@ -138,7 +138,7 @@ class CompiledStringTemplateTest < Minitest::Test
       line = boom.backtrace.first
       line = boom.backtrace.grep(/^test\.str:/).first
       assert line, "Backtrace didn't contain test.str"
-      file, line, meth = line.split(":")
+      _file, line, _meth = line.split(":")
       assert_equal '13', line
     end
   end
@@ -153,7 +153,7 @@ class CompiledStringTemplateTest < Minitest::Test
     rescue => boom
       assert_kind_of RuntimeError, boom
       line = boom.backtrace.first
-      file, line, meth = line.split(":")
+      file, line, _meth = line.split(":")
       assert_equal 'test.str', file
       assert_equal '6', line
     end

--- a/test/tilt_typescript_test.rb
+++ b/test/tilt_typescript_test.rb
@@ -29,6 +29,6 @@ begin
       3.times { assert_match @js, template.render }
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::TypeScriptTemplate (disabled)"
 end

--- a/test/tilt_typescript_test.rb
+++ b/test/tilt_typescript_test.rb
@@ -21,7 +21,7 @@ begin
 
     test "supports source map" do
       template = Tilt::TypeScriptTemplate.new(inlineSourceMap: true)  { @ts }
-      assert_match /sourceMappingURL/, template.render
+      assert_match %r(sourceMappingURL), template.render
     end
 
     test "can be rendered more than once" do

--- a/test/tilt_wikiclothtemplate_test.rb
+++ b/test/tilt_wikiclothtemplate_test.rb
@@ -27,6 +27,6 @@ begin
       3.times { assert_match /<h1>.*Hello World!.*<\/h1>/m, template.render }
     end
   end
-rescue LoadError => boom
+rescue LoadError
   warn "Tilt::WikiClothTemplate (disabled)"
 end

--- a/test/tilt_wikiclothtemplate_test.rb
+++ b/test/tilt_wikiclothtemplate_test.rb
@@ -19,12 +19,12 @@ begin
 
     test "compiles and evaluates the template on #render" do
       template = Tilt::WikiClothTemplate.new { |t| "= Hello World! =" }
-      assert_match /<h1>.*Hello World!.*<\/h1>/m, template.render
+      assert_match(/<h1>.*Hello World!.*<\/h1>/m, template.render)
     end
 
     test "can be rendered more than once" do
       template = Tilt::WikiClothTemplate.new { |t| "= Hello World! =" }
-      3.times { assert_match /<h1>.*Hello World!.*<\/h1>/m, template.render }
+      3.times { assert_match(/<h1>.*Hello World!.*<\/h1>/m, template.render) }
     end
   end
 rescue LoadError


### PR DESCRIPTION
Here's an attempt to eliminate all ruby warnings in this repo.
We still see so many warnings from other bundled libraries, but I believe it's a good habit to at least keep our code base warning-free.