### PR TITLE
Always sort locals by strings (Fixes #306)

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -5,8 +5,6 @@ module Tilt
   TOPOBJECT = Object.superclass || Object
   # @private
   LOCK = Mutex.new
-  # @private
-  SYMBOL_ARRAY_SORTABLE = RUBY_VERSION >= '1.9'
 
   # Base class for template implementations. Subclasses must implement
   # the #prepare method and one of the #evaluate or #precompiled_template
@@ -158,11 +156,7 @@ module Tilt
     # override render() may not support all features.
     def evaluate(scope, locals, &block)
       locals_keys = locals.keys
-      if SYMBOL_ARRAY_SORTABLE
-        locals_keys.sort!
-      else
-        locals_keys.sort!{|x, y| x.to_s <=> y.to_s}
-      end
+      locals_keys.sort!{|x, y| x.to_s <=> y.to_s}
       method = compiled_method(locals_keys)
       method.bind(scope).call(locals, &block)
     end

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -132,6 +132,12 @@ class TiltTemplateTest < Minitest::Test
     assert inst.prepared?
   end
 
+  test "template_source with locals of strings" do
+    inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{name}!' }
+    assert_equal "Hey Joe!", inst.render(Object.new, 'name' => 'Joe', :name=>'Joe')
+    assert inst.prepared?
+  end
+
   test "template_source with locals having non-variable keys raises error" do
     inst = SourceGeneratingMockTemplate.new { |t| '1 + 2 = #{_answer}' }
     err = assert_raises(RuntimeError) { inst.render(Object.new, 'ANSWER' => 3) }


### PR DESCRIPTION
Fixes issues when mixing string locals with symbol locals.