### PR TITLE
Add support for Erubi template engine for erb and rhtml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Support for these template engines is included with the package:
 | Asciidoctor             | .ad, .adoc, .asciidoc  | asciidoctor (>= 0.1.0)                     | Community   |
 | ERB                     | .erb, .rhtml           | none (included ruby stdlib)                | Tilt team   |
 | InterpolatedString      | .str                   | none (included ruby core)                  | Tilt team   |
+| Erubi                   | .erb, .rhtml, .erubi   | erubi                                      | Community   |
 | Erubis                  | .erb, .rhtml, .erubis  | erubis                                     | Tilt team   |
 | Haml                    | .haml                  | haml                                       | Tilt team   |
 | Sass                    | .sass                  | haml (< 3.1) or sass (>= 3.1)              | Tilt team   |

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -117,6 +117,7 @@ module Tilt
   # ERB
   register_lazy :ERBTemplate,    'tilt/erb',    'erb', 'rhtml'
   register_lazy :ErubisTemplate, 'tilt/erubis', 'erb', 'rhtml', 'erubis'
+  register_lazy :ErubiTemplate,  'tilt/erubi',  'erb', 'rhtml', 'erubi'
 
   # Markdown
   register_lazy :BlueClothTemplate,    'tilt/bluecloth',    'markdown', 'mkd', 'md'

--- a/lib/tilt/erubi.rb
+++ b/lib/tilt/erubi.rb
@@ -1,0 +1,32 @@
+require 'tilt/template'
+require 'erubi'
+
+module Tilt
+  # Erubi (a simplified version of Erubis) template implementation.
+  # See https://github.com/jeremyevans/erubi
+  #
+  # ErubiTemplate supports the following additional options, in addition
+  # to the options supported by the Erubi engine:
+  #
+  # :engine_class :: allows you to specify a custom engine class to use
+  #                  instead of the default (which is ::Erubi::Engine).
+  class ErubiTemplate < Template
+    def prepare
+      @options.merge!(:preamble => false, :postamble => false, :ensure=>true)
+
+      engine_class = @options[:engine_class] || Erubi::Engine
+
+      @engine = engine_class.new(data, @options)
+      @outvar = @engine.bufvar
+
+      # Remove dup after tilt supports frozen source.
+      @src = @engine.src.dup
+
+      @engine
+    end
+
+    def precompiled_template(locals)
+      @src
+    end
+  end
+end

--- a/test/tilt_erubitemplate_test.rb
+++ b/test/tilt_erubitemplate_test.rb
@@ -1,0 +1,158 @@
+require 'test_helper'
+require 'tilt'
+
+begin
+  require 'tilt/erubi'
+  class ErubiTemplateTest < Minitest::Test
+    test "registered for '.erubi' files" do
+      assert_equal Tilt::ErubiTemplate, Tilt['test.erubi']
+      assert_equal Tilt::ErubiTemplate, Tilt['test.html.erubi']
+    end
+
+    test "registered above ERB and Erubis" do
+      %w[erb rhtml].each do |ext|
+        lazy = Tilt.lazy_map[ext]
+        erubi_idx = lazy.index { |klass, file| klass == 'Tilt::ErubiTemplate' }
+        erubis_idx = lazy.index { |klass, file| klass == 'Tilt::ErubisTemplate' }
+        erb_idx = lazy.index { |klass, file| klass == 'Tilt::ERBTemplate' }
+        assert erubi_idx < erubis_idx,
+          "#{erubi_idx} should be lower than #{erubis_idx}"
+        assert erubi_idx < erb_idx,
+          "#{erubi_idx} should be lower than #{erb_idx}"
+      end
+    end
+
+    test "preparing and evaluating templates on #render" do
+      template = Tilt::ErubiTemplate.new { |t| "Hello World!" }
+      assert_equal "Hello World!", template.render
+    end
+
+    test "can be rendered more than once" do
+      template = Tilt::ErubiTemplate.new { |t| "Hello World!" }
+      3.times { assert_equal "Hello World!", template.render }
+    end
+
+    test "passing locals" do
+      template = Tilt::ErubiTemplate.new { 'Hey <%= name %>!' }
+      assert_equal "Hey Joe!", template.render(Object.new, :name => 'Joe')
+    end
+
+    test "evaluating in an object scope" do
+      template = Tilt::ErubiTemplate.new { 'Hey <%= @name %>!' }
+      scope = Object.new
+      scope.instance_variable_set :@name, 'Joe'
+      assert_equal "Hey Joe!", template.render(scope)
+    end
+
+    class MockOutputVariableScope
+      attr_accessor :exposed_buffer
+    end
+
+    test "exposing the buffer to the template by default" do
+      template = Tilt::ErubiTemplate.new(nil, :bufvar=>'@_out_buf') { '<% self.exposed_buffer = @_out_buf %>hey' }
+      scope = MockOutputVariableScope.new
+      template.render(scope)
+      refute_nil scope.exposed_buffer
+      assert_equal scope.exposed_buffer, 'hey'
+    end
+
+    test "passing a block for yield" do
+      template = Tilt::ErubiTemplate.new { 'Hey <%= yield %>!' }
+      assert_equal "Hey Joe!", template.render { 'Joe' }
+    end
+
+    test "backtrace file and line reporting without locals" do
+      data = File.read(__FILE__).split("\n__END__\n").last
+      fail unless data[0] == ?<
+      template = Tilt::ErubiTemplate.new('test.erubis', 11) { data }
+      begin
+        template.render
+        fail 'should have raised an exception'
+      rescue => boom
+        assert_kind_of NameError, boom
+        line = boom.backtrace.grep(/^test\.erubis:/).first
+        assert line, "Backtrace didn't contain test.erubis"
+        _file, line, _meth = line.split(":")
+        assert_equal '13', line
+      end
+    end
+
+    test "backtrace file and line reporting with locals" do
+      data = File.read(__FILE__).split("\n__END__\n").last
+      fail unless data[0] == ?<
+      template = Tilt::ErubiTemplate.new('test.erubis', 1) { data }
+      begin
+        template.render(nil, :name => 'Joe', :foo => 'bar')
+        fail 'should have raised an exception'
+      rescue => boom
+        assert_kind_of RuntimeError, boom
+        line = boom.backtrace.first
+        file, line, _meth = line.split(":")
+        assert_equal 'test.erubis', file
+        assert_equal '6', line
+      end
+    end
+
+    test "erubis template options" do
+      template = Tilt::ErubiTemplate.new(nil, :escapefunc=> 'h') { 'Hey <%== @name %>!' }
+      scope = Object.new
+      def scope.h(s) s * 2 end
+      scope.instance_variable_set :@name, 'Joe'
+      assert_equal "Hey JoeJoe!", template.render(scope)
+    end
+
+    test "using an instance variable as the outvar" do
+      template = Tilt::ErubiTemplate.new(nil, :outvar => '@buf') { "<%= 1 + 1 %>" }
+      scope = Object.new
+      scope.instance_variable_set(:@buf, 'original value')
+      assert_equal '2', template.render(scope)
+      assert_equal 'original value', scope.instance_variable_get(:@buf)
+    end
+
+    test "using Erubi::CaptureEndEngine subclass via :engine_class option" do
+      require 'erubi/capture_end'
+      def self.bar
+        @a << "a"
+        yield
+        @a << 'b'
+        @a.upcase
+      end
+      template = Tilt::ErubiTemplate.new(nil, :engine_class => ::Erubi::CaptureEndEngine, :bufvar=>'@a') { 'c<%|= bar do %>d<%| end %>e' }
+      assert_equal "cADBe", template.render(self)
+    end
+
+    test "using :escape_html => true option" do
+      template = Tilt::ErubiTemplate.new(nil, :escape_html => true) { |t| %(<%= "<p>Hello World!</p>" %>) }
+      assert_equal "&lt;p&gt;Hello World!&lt;/p&gt;", template.render
+    end
+
+    test "using :escape_html => false option" do
+      template = Tilt::ErubiTemplate.new(nil, :escape_html => false) { |t| %(<%= "<p>Hello World!</p>" %>) }
+      assert_equal "<p>Hello World!</p>", template.render
+    end
+
+    test "erubi default does not escape html" do
+      template = Tilt::ErubiTemplate.new { |t| %(<%= "<p>Hello World!</p>" %>) }
+      assert_equal "<p>Hello World!</p>", template.render
+    end
+
+    test "does not modify options argument" do
+      options_hash = {:escape_html => true}
+      Tilt::ErubiTemplate.new(nil, options_hash) { |t| "Hello World!" }
+      assert_equal({:escape_html => true}, options_hash)
+    end
+  end
+rescue LoadError
+  warn "Tilt::ErubiTemplate (disabled)"
+end
+
+__END__
+<html>
+<body>
+  <h1>Hey <%= name %>!</h1>
+
+
+  <p><% fail %></p>
+</body>
+</html>
+


### PR DESCRIPTION
Erubi is a simplified fork of Erubis with the following advantages:

* Handles postfix conditionals when using escaping (e.g. <tt><%= foo if bar %></tt>)
* Works with ruby's --enable-frozen-string-literal option
* Automatically freezes strings for template text when ruby optimizes it (on ruby 2.1+)
* Escapes ' (apostrophe) when escaping for better XSS protection
* Has 88% smaller memory footprint for base engine
* Has 75% smaller memory footprint for tilt support
* Does no monkey patching (Erubis adds a method to Kernel)
* Has simpler internals (1 file, <150 lines of code)
* Has an open development model (Erubis doesn't have a public source control repository or bug tracker)
* Is not dead (Erubis hasn't been updated since 2011)

With this patch, Erubi will be tried before Erubis and ERB.

Erubi will become Rails' default ERB template engine starting in Rails 5.1 (https://github.com/rails/rails/commit/7da8d76206271bdf200ea201f7e5a49afb9bc9e7).