### PR TITLE
Do not modify BasicObject during template compilation on ruby 2.0+

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -2,7 +2,16 @@ require 'thread'
 
 module Tilt
   # @private
-  TOPOBJECT = Object.superclass || Object
+  TOPOBJECT = if RUBY_VERSION >= '2.0'
+    # @private
+    module CompiledTemplates
+      self
+    end
+  elsif RUBY_VERSION >= '1.9'
+    BasicObject
+  else
+    Object
+  end
   # @private
   LOCK = Mutex.new
 


### PR DESCRIPTION
Starting in ruby 2.0, you can unbind methods from modules and
bind them to any object, and then call them.  There is no reason
to modify the BasicObject class in this case.

This fixes tilt's template compilation on ruby 2.0+ when BasicObject
is frozen.