### PR TITLE
Update yard for had unsupported last_comment method in rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rake'
 gem 'minitest', '~> 5.0'
 
 group :development do
-  gem 'yard', '~> 0.8.6'
+  gem 'yard', '~> 0.9.0'
   gem 'ronn', '~> 0.7.3'
 end
 


### PR DESCRIPTION
The error occurs when we do HACKING because removed deprecated method named `last_comment` in rake >= 12.0.0.

```
$ rake

rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x007f88cb4b7e58>
```