### PR TITLE
Use Haml 5's new API to avoid using deprecated private method.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ can_execjs = (RUBY_VERSION >= '1.9.3')
 
 group :primary do
   gem 'builder'
-  gem 'haml', '>= 2.2.11', '< 4'
+  gem 'haml', '>= 4'
   gem 'erubis'
   gem 'markaby'
   gem 'sass'

--- a/lib/tilt/haml.rb
+++ b/lib/tilt/haml.rb
@@ -7,51 +7,74 @@ module Tilt
   class HamlTemplate < Template
     self.default_mime_type = 'text/html'
 
-    def prepare
-      options = @options.merge(:filename => eval_file, :line => line)
-      @engine = ::Haml::Engine.new(data, options)
-    end
-
-    def evaluate(scope, locals, &block)
-      raise ArgumentError, 'invalid scope: must not be frozen' if scope.frozen?
-
-      if @engine.respond_to?(:precompiled_method_return_value, true)
-        super
-      else
-        @engine.render(scope, locals, &block)
+    # `Gem::Version.correct?` may return false because of Haml::VERSION #=> "3.1.8 (Separated Sally)". After Haml 4, it's always correct.
+    if Gem::Version.correct?(Haml::VERSION) && Gem::Version.new(Haml::VERSION) >= Gem::Version.new('5.0.0.beta.2')
+      def prepare
+        @engine = ::Haml::TempleEngine.new(@options.merge(filename: eval_file, line: line))
+        @engine.compile(data)
       end
-    end
 
-    # Precompiled Haml source. Taken from the precompiled_with_ambles
-    # method in Haml::Precompiler:
-    # http://github.com/nex3/haml/blob/master/lib/haml/precompiler.rb#L111-126
-    def precompiled_template(locals)
-      @engine.precompiled
-    end
+      def evaluate(scope, locals, &block)
+        raise ArgumentError, 'invalid scope: must not be frozen' if scope.frozen?
+        super
+      end
 
-    def precompiled_preamble(locals)
-      local_assigns = super
-      @engine.instance_eval do
-        <<-RUBY
-          begin
-            extend Haml::Helpers
-            _hamlout = @haml_buffer = Haml::Buffer.new(@haml_buffer, #{options_for_buffer.inspect})
-            _erbout = _hamlout.buffer
+      def precompiled_template(locals)
+        @engine.precompiled_with_ambles(
+          [],
+          after_preamble: <<-RUBY
             __in_erb_template = true
             _haml_locals = locals
-            #{local_assigns}
-        RUBY
+          RUBY
+        )
       end
-    end
+    else # Following definitions are for Haml <= 4 and deprecated.
+      def prepare
+        options = @options.merge(:filename => eval_file, :line => line)
+        @engine = ::Haml::Engine.new(data, options)
+      end
 
-    def precompiled_postamble(locals)
-      @engine.instance_eval do
-        <<-RUBY
-            #{precompiled_method_return_value}
-          ensure
-            @haml_buffer = @haml_buffer.upper if @haml_buffer
-          end
-        RUBY
+      def evaluate(scope, locals, &block)
+        raise ArgumentError, 'invalid scope: must not be frozen' if scope.frozen?
+
+        if @engine.respond_to?(:precompiled_method_return_value, true)
+          super
+        else
+          @engine.render(scope, locals, &block)
+        end
+      end
+
+      # Precompiled Haml source. Taken from the precompiled_with_ambles
+      # method in Haml::Precompiler:
+      # http://github.com/nex3/haml/blob/master/lib/haml/precompiler.rb#L111-126
+      def precompiled_template(locals)
+        @engine.precompiled
+      end
+
+      def precompiled_preamble(locals)
+        local_assigns = super
+        @engine.instance_eval do
+          <<-RUBY
+            begin
+              extend Haml::Helpers
+              _hamlout = @haml_buffer = Haml::Buffer.new(@haml_buffer, #{options_for_buffer.inspect})
+              _erbout = _hamlout.buffer
+              __in_erb_template = true
+              _haml_locals = locals
+              #{local_assigns}
+          RUBY
+        end
+      end
+
+      def precompiled_postamble(locals)
+        @engine.instance_eval do
+          <<-RUBY
+              #{precompiled_method_return_value}
+            ensure
+              @haml_buffer = @haml_buffer.upper if @haml_buffer
+            end
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rtomayko/tilt/issues/311

In https://github.com/haml/haml/pull/896, I've already implemented API exactly for this issue. After this change is released by tilt, I'll change Haml to depend on tilt after that version. Hopefully it'll be Haml 5.0.0.