### PR TITLE
Set buffer options from outvar option by Sinatra

### DIFF
--- a/lib/tilt/haml.rb
+++ b/lib/tilt/haml.rb
@@ -10,7 +10,12 @@ module Tilt
     # `Gem::Version.correct?` may return false because of Haml::VERSION #=> "3.1.8 (Separated Sally)". After Haml 4, it's always correct.
     if Gem::Version.correct?(Haml::VERSION) && Gem::Version.new(Haml::VERSION) >= Gem::Version.new('5.0.0.beta.2')
       def prepare
-        @engine = ::Haml::TempleEngine.new(@options.merge(filename: eval_file, line: line))
+        options = {}.update(@options).update(filename: eval_file, line: line)
+        if options.include?(:outvar)
+          options[:buffer] = options.delete(:outvar)
+          options[:save_buffer] = true
+        end
+        @engine = ::Haml::TempleEngine.new(options)
         @engine.compile(data)
       end
 


### PR DESCRIPTION
Fix #316.
ERB, Erubis and Slim solves the problem in Tilt layer. Then Haml follows it.

This is intended to be the same as https://github.com/judofyr/temple/blob/v0.8.0/lib/temple/templates/tilt.rb#L26-L29.
Actually it won't affect Haml 5 for now but I'll change Haml's generator to follow Temple's default option later. 

Since it's supported by `Temple::Engine` level, this change will fix warning without changing Haml.