### PR TITLE
Limit Haml to v4 in Ruby < 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,11 @@ can_execjs = (RUBY_VERSION >= '1.9.3')
 
 group :primary do
   gem 'builder'
-  gem 'haml', '>= 4'
+  if RUBY_VERSION >= '2.0.0'
+    gem 'haml', '>= 4'
+  else
+    gem 'haml', '~> 4'
+  end
   gem 'erubis'
   gem 'markaby'
   gem 'sass'


### PR DESCRIPTION
This PR fixes Travis failure caused by https://github.com/rtomayko/tilt/pull/312 and Haml 5.0.0 release.