### PR TITLE
Avoid uninitialized instance var @haml_buffer

### DIFF
--- a/lib/tilt/haml.rb
+++ b/lib/tilt/haml.rb
@@ -62,7 +62,7 @@ module Tilt
           <<-RUBY
             begin
               extend Haml::Helpers
-              _hamlout = @haml_buffer = Haml::Buffer.new(@haml_buffer, #{options_for_buffer.inspect})
+              _hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{options_for_buffer.inspect})
               _erbout = _hamlout.buffer
               __in_erb_template = true
               _haml_locals = locals
@@ -76,7 +76,7 @@ module Tilt
           <<-RUBY
               #{precompiled_method_return_value}
             ensure
-              @haml_buffer = @haml_buffer.upper if @haml_buffer
+              @haml_buffer = @haml_buffer.upper if haml_buffer
             end
           RUBY
         end


### PR DESCRIPTION
Hi, and thanks for maintaining this library.

I'm polishing the test suite of Sinatra, trying to get it to have less warning output.

The [precompiled_preamble](https://github.com/rtomayko/tilt/blob/8e53a8c7b12c61a6698695f8b7f0fa83619512f3/lib/tilt/haml.rb#L65), has this line:

```ruby
_hamlout = @haml_buffer = Haml::Buffer.new(@haml_buffer, #{options_for_buffer.inspect})
```

Can it be the cause of these Ruby warnings?

> warning: instance variable @haml_buffer not initialized

I wonder if it could be remedied with a change to

```ruby
_hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{options_for_buffer.inspect})
```

See code for [`haml_buffer`](https://github.com/haml/haml/blob/b61c6bc2c53e8a5d3c11e2d76c7cfde75cf941ab/lib/haml/helpers.rb#L674-L679).

Does this change make sense to you? 



