### PR TITLE
Allow question mark in local method names

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -239,8 +239,8 @@ module Tilt
 
     def local_extraction(local_keys)
       local_keys.map do |k|
-        if k.to_s =~ /\A[a-z_][a-zA-Z_0-9]*\z/
-          "#{k} = locals[#{k.inspect}]"
+        if k.to_s =~ /\A[a-z_][a-zA-Z_0-9]*\??\z/
+          "define_singleton_method(#{k.inspect}.to_sym) do; locals[#{k.inspect}]; end"
         else
           raise "invalid locals key: #{k.inspect} (keys must be variable names)"
         end

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -134,7 +134,13 @@ class TiltTemplateTest < Minitest::Test
 
   test "template_source with locals of strings" do
     inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{name}!' }
-    assert_equal "Hey Joe!", inst.render(Object.new, 'name' => 'Joe', :name=>'Joe')
+    assert_equal "Hey Joe!", inst.render(Object.new, 'name' => 'Joe', :name => 'Joe')
+    assert inst.prepared?
+  end
+
+  test "template_source with locals of string question mark" do
+    inst = SourceGeneratingMockTemplate.new { |t| 'Name? #{has_a_name?}' }
+    assert_equal "Name? true", inst.render(Object.new, 'has_a_name?' => true, has_a_name?: true)
     assert inst.prepared?
   end
 


### PR DESCRIPTION
I think name with question mark should be allowed as local method name.

What do you think?