### PR TITLE
Rename `-rubygems` option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ desc 'Run tests (default)'
 Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/*_test.rb']
   t.ruby_opts = ['-Itest']
-  t.ruby_opts << '-rubygems' if defined? Gem
+  t.ruby_opts << '-rrubygems' if defined? Gem
   t.warning = false
 end
 


### PR DESCRIPTION
This PR fixes the following error.

```console
% ruby -v
ruby 2.6.0dev (2018-03-03 trunk 62644) [x86_64-darwin17]
% be rake
Traceback (most recent call last):
        1: from
  /Users/koic/.rbenv/versions/2.6.0-dev/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:59:in
  `require'
/Users/koic/.rbenv/versions/2.6.0-dev/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:59:in
  `require': cannot load such file -- ubygems (LoadError)
rake aborted!
Command failed with status (1)
/Users/koic/.rbenv/versions/2.6.0-dev/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.6.0-dev/bin/bundle:23:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```

The `-rubygems` option has been removed at Ruby 2.5.

Refer rubygems/rubygems#2027.