### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/tilt/erb.rb
+++ b/lib/tilt/erb.rb
@@ -19,7 +19,11 @@ module Tilt
     def prepare
       @outvar = options[:outvar] || self.class.default_output_variable
       options[:trim] = '<>' if !(options[:trim] == false) && (options[:trim].nil? || options[:trim] == true)
-      @engine = ::ERB.new(data, options[:safe], options[:trim], @outvar)
+      @engine = if ::ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+        ::ERB.new(data, trim_mode: options[:trim], eoutvar: @outvar)
+      else
+        ::ERB.new(data, options[:safe], options[:trim], @outvar)
+      end
     end
 
     def precompiled_template(locals)


### PR DESCRIPTION
This PR suppresses the following warnings.

```console
% ruby -v
ruby 2.6.0dev (2018-03-03 trunk 62644) [x86_64-darwin17]
% RUBYOPT=-w bundle exec rake
(snip)
./Users/koic/src/github.com/rtomayko/tilt/lib/tilt/erb.rb:22: warning:
Passing safe_level with the 2nd argument of ERB.new is deprecated. Do
not use it, and specify other arguments as keyword arguments.
/Users/koic/src/github.com/rtomayko/tilt/lib/tilt/erb.rb:22: warning:
Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use
keyword argument like ERB.new(str, trim_mode: ...) instead.
/Users/koic/src/github.com/rtomayko/tilt/lib/tilt/erb.rb:22: warning:
Passing eoutvar with the 4th argument of ERB.new is deprecated. Use
keyword argument like ERB.new(str, eoutvar: ...) instead.
```

The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087b685e8dc0f21f4a89875f25c22f5c39a9/NEWS#stdlib-updates-outstanding-ones-only

The following address is related Ruby's commit.
https://github.com/ruby/ruby/commit/cc777d0

This PR uses `ERB.instance_method(:initialize).parameters.assoc(:key)` to switch `ERB.new` interface. Because Tilt supports multiple Ruby versions, it need to use the appropriate interface.

This patch is built into Ruby.
https://github.com/ruby/ruby/commit/3406c5d