### PR TITLE
Replace deprecated sass gem with sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,10 @@ group :primary do
   gem 'haml', '>= 4' if RUBY_VERSION >= '2.0.0'
   gem 'erubis'
   gem 'markaby'
-  gem 'sass'
+  gem 'sassc'
 
   if can_execjs
+    gem 'therubyracer' # needed by 'less'
     gem 'less'
     gem 'coffee-script'
     gem 'livescript'

--- a/lib/tilt/sass.rb
+++ b/lib/tilt/sass.rb
@@ -1,5 +1,5 @@
 require 'tilt/template'
-require 'sass'
+require 'sassc'
 
 module Tilt
   # Sass template implementation. See:
@@ -10,7 +10,7 @@ module Tilt
     self.default_mime_type = 'text/css'
 
     def prepare
-      @engine = ::Sass::Engine.new(data, sass_options)
+      @engine = ::SassC::Engine.new(data, sass_options)
     end
 
     def evaluate(scope, locals, &block)


### PR DESCRIPTION
Ruby Sass is deprecated and will no longer be supported from 26 March 2019; see [the official announcement](https://sass.logdown.com/posts/7081811) and the [planned repository structure for a post-Ruby-Sass world](https://github.com/sass/sass/issues/2480).

Fortunately, [`sass/sassc-ruby`](https://github.com/sass/sassc-ruby) exists as a wrapper around the Sass C implementation, and is a near-drop-in replacement for [`ruby-sass`](https://github.com/sass/ruby-sass).

All that is required to make the change is to bundle and require 'sassc' rather than 'sass', and change the outer-namespace constant from `::Sass` to `::SassC` (e.g., in [`Tilt::SassTemplate#prepare`](https://github.com/jdickey/tilt/blob/53deb84/lib/tilt/sass.rb#L13)).

Given the number of other projects that depend on Tilt and the impending approach of `sass-ruby`'s EOL, getting this done early would be Helpful.