### PR TITLE
Remove test files from bundled gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ file 'tilt.gemspec' => FileList['{lib,test}/**','Rakefile'] do |f|
     sub(/s\.version\s*=\s*'.*'/, "s.version = '#{version}'")
   parts = spec.split("  # = MANIFEST =\n")
   # determine file list from git ls-files
-  files = `git ls-files`.
+  files = `git ls-files -- lib bin COPYING`.
     split("\n").sort.reject{ |file| file =~ /^\./ }.
     map{ |file| "    #{file}" }.join("\n")
   # piece file back together and write...

--- a/tilt.gemspec
+++ b/tilt.gemspec
@@ -15,15 +15,8 @@ Gem::Specification.new do |s|
 
   # = MANIFEST =
   s.files = %w[
-    CHANGELOG.md
     COPYING
-    Gemfile
-    HACKING
-    README.md
-    Rakefile
     bin/tilt
-    docs/TEMPLATES.md
-    docs/common.css
     lib/tilt.rb
     lib/tilt/asciidoc.rb
     lib/tilt/babel.rb
@@ -63,65 +56,10 @@ Gem::Specification.new do |s|
     lib/tilt/typescript.rb
     lib/tilt/wikicloth.rb
     lib/tilt/yajl.rb
-    man/index.txt
-    man/tilt.1.ronn
-    test/markaby/locals.mab
-    test/markaby/markaby.mab
-    test/markaby/markaby_other_static.mab
-    test/markaby/render_twice.mab
-    test/markaby/scope.mab
-    test/markaby/yielding.mab
-    test/mytemplate.rb
-    test/test_helper.rb
-    test/tilt_asciidoctor_test.rb
-    test/tilt_babeltemplate.rb
-    test/tilt_blueclothtemplate_test.rb
-    test/tilt_buildertemplate_test.rb
-    test/tilt_cache_test.rb
-    test/tilt_coffeescripttemplate_test.rb
-    test/tilt_commonmarkertemplate_test.rb
-    test/tilt_compilesite_test.rb
-    test/tilt_creoletemplate_test.rb
-    test/tilt_csv_test.rb
-    test/tilt_erbtemplate_test.rb
-    test/tilt_erubistemplate_test.rb
-    test/tilt_erubitemplate_test.rb
-    test/tilt_etannitemplate_test.rb
-    test/tilt_hamltemplate_test.rb
-    test/tilt_kramdown_test.rb
-    test/tilt_lesstemplate_test.less
-    test/tilt_lesstemplate_test.rb
-    test/tilt_liquidtemplate_test.rb
-    test/tilt_livescripttemplate_test.rb
-    test/tilt_mapping_test.rb
-    test/tilt_markaby_test.rb
-    test/tilt_markdown_test.rb
-    test/tilt_marukutemplate_test.rb
-    test/tilt_metadata_test.rb
-    test/tilt_nokogiritemplate_test.rb
-    test/tilt_pandoctemplate_test.rb
-    test/tilt_prawntemplate.prawn
-    test/tilt_prawntemplate_test.rb
-    test/tilt_radiustemplate_test.rb
-    test/tilt_rdiscounttemplate_test.rb
-    test/tilt_rdoctemplate_test.rb
-    test/tilt_redcarpettemplate_test.rb
-    test/tilt_redclothtemplate_test.rb
-    test/tilt_rstpandoctemplate_test.rb
-    test/tilt_sasstemplate_test.rb
-    test/tilt_sigil_test.rb
-    test/tilt_stringtemplate_test.rb
-    test/tilt_template_test.rb
-    test/tilt_test.rb
-    test/tilt_typescript_test.rb
-    test/tilt_wikiclothtemplate_test.rb
-    test/tilt_yajltemplate_test.rb
-    tilt.gemspec
   ]
   # = MANIFEST =
 
   s.executables = ['tilt']
-  s.test_files = s.files.select {|path| path =~ /^test\/.*_test.rb/}
 
   s.homepage = "http://github.com/rtomayko/tilt/"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Tilt", "--main", "Tilt"]


### PR DESCRIPTION
First of all, thanks for Tilt!

This PR slims down the bundled gem by ~60% by:
- removing the `test_files` declaration (which is [deprecated](https://github.com/rubygems/guides/issues/90))
- removing all files which aren't required to build the gem from the `files` declaration. This is pretty standard practice

The same saving is a big percentage but small in absolute terms (30KB different in the `.gem`). Hopefully that's still worth having since this gem is downloaded millions of times.