### PR TITLE
Fix warning on Ruby 2.7 when using yield in templates

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -166,7 +166,7 @@ module Tilt
     def evaluate(scope, locals, &block)
       locals_keys = locals.keys
       locals_keys.sort!{|x, y| x.to_s <=> y.to_s}
-      method = compiled_method(locals_keys, scope.class)
+      method = compiled_method(locals_keys, scope.is_a?(Module) ? scope : scope.class)
       method.bind(scope).call(locals, &block)
     end
 

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -199,6 +199,11 @@ class TiltTemplateTest < Minitest::Test
     assert_equal "Hey Bob!", inst.render(Person.new("Joe"))
   end
 
+  test "template which accesses a constant using scope class" do
+    inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{CONSTANT}!' }
+    assert_equal "Hey Bob!", inst.render(Person)
+  end
+
   test "populates Tilt.current_template during rendering" do
     inst = SourceGeneratingMockTemplate.new { '#{$inst = Tilt.current_template}' }
     inst.render


### PR DESCRIPTION
This fixes the following warning:

```
warning: `yield' in class syntax will not be supported from Ruby 3.0. [Feature #15575].
```

Considering that yield is how layout templates work in Tilt, I think this is an important change to allow people to start testing their applications that use Tilt with ruby 2.7.0-preview1.