### PR TITLE
Handle rendering BasicObject instances

### DIFF
--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -204,6 +204,38 @@ class TiltTemplateTest < Minitest::Test
     assert_equal "Hey Bob!", inst.render(Person)
   end
 
+  class BasicPerson < BasicObject
+    CONSTANT = "Bob"
+
+    attr_accessor :name
+    def initialize(name)
+      @name = name
+    end
+  end
+
+  test "template_source with an BasicObject scope" do
+    inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{@name}!' }
+    scope = BasicPerson.new('Joe')
+    assert_equal "Hey Joe!", inst.render(scope)
+  end
+
+  test "template_source with a block for yield using BasicObject instance" do
+    inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{yield}!' }
+    assert_equal "Hey Joe!", inst.render(BasicObject.new){ 'Joe' }
+  end
+
+  if RUBY_VERSION >= '2'
+    test "template which accesses a BasicObject constant" do
+      inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{CONSTANT}!' }
+      assert_equal "Hey Bob!", inst.render(BasicPerson.new("Joe"))
+    end
+  end
+
+  test "template which accesses a constant using BasicObject scope class" do
+    inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{CONSTANT}!' }
+    assert_equal "Hey Bob!", inst.render(BasicPerson)
+  end
+
   test "populates Tilt.current_template during rendering" do
     inst = SourceGeneratingMockTemplate.new { '#{$inst = Tilt.current_template}' }
     inst.render


### PR DESCRIPTION
There are a couple of issues here.  One is that BasicObjects do
not respond to is_a?.  Another is that they don't respond to
class.

To handle the class issue, use a case statement to separate
BasicObject from Object, and bind a Kernel method to the BasicObject
instance to be able to get the class.  Note that this does not work
on Ruby 1.9, and on Ruby 1.9, there is not a way to correctly get
the scope class.  Use Object in that case so things don't completely
break (though constant lookup will not use use the scope class).

While we don't need to handle is_a? after that change, still switch
from scope.is_a?(Module) to Module === scope, as that handles cases
where is_a? is redefined.

Related to #347