### PR TITLE
Support UNSAFE commonmarker option

### DIFF
--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -11,6 +11,7 @@ module Tilt
     PARSE_OPTIONS = [
       :SMART,
       :smartypants,
+      :UNSAFE,
     ].freeze
     RENDER_OPTIONS = [
       :GITHUB_PRE_LANG,
@@ -18,6 +19,7 @@ module Tilt
       :NOBREAKS,
       :SAFE,
       :SOURCEPOS,
+      :UNSAFE,
     ].freeze
     EXTENSIONS = [
       :autolink,


### PR DESCRIPTION
Accept `:UNSAFE` options for commonmarker config. 

Behaviour was changed to SAFE by default: gjtorikian/commonmarker#87 gjtorikian/commonmarker#81
