### PR TITLE
Allows you to use :escape_html as documented

### DIFF
--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -9,6 +9,9 @@ module Tilt
       :smartypants => :SMART,
       :escape_html => :UNSAFE,
     }
+    INVERT_OPTIONS = [
+      :escape_html,
+    ]
     PARSE_OPTIONS = [
       :SMART,
       :smartypants,
@@ -37,7 +40,11 @@ module Tilt
 
     def parse_options
       raw_options = PARSE_OPTIONS.select do |option|
-        options[option]
+        if INVERT_OPTIONS.include? option
+          !options[option]
+        else
+          options[option]
+        end
       end
       actual_options = raw_options.map do |option|
         OPTION_ALIAS[option] || option
@@ -52,7 +59,11 @@ module Tilt
 
     def render_options
       raw_options = RENDER_OPTIONS.select do |option|
-        options[option]
+        if INVERT_OPTIONS.include? option
+          !options[option]
+        else
+          options[option]
+        end
       end
       actual_options = raw_options.map do |option|
         OPTION_ALIAS[option] || option

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -21,7 +21,6 @@ module Tilt
       :HARDBREAKS,
       :NOBREAKS,
       :SOURCEPOS,
-      :SAFE,
       :UNSAFE,
       :escape_html,
     ].freeze

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -6,7 +6,8 @@ module Tilt
     self.default_mime_type = 'text/html'
 
     OPTION_ALIAS = {
-      :smartypants => :SMART
+      :smartypants => :SMART,
+      :escape_html => :UNSAFE,
     }
     PARSE_OPTIONS = [
       :SMART,
@@ -16,8 +17,10 @@ module Tilt
       :GITHUB_PRE_LANG,
       :HARDBREAKS,
       :NOBREAKS,
-      :SAFE,
       :SOURCEPOS,
+      :SAFE,
+      :UNSAFE,
+      :escape_html,
     ].freeze
     EXTENSIONS = [
       :autolink,


### PR DESCRIPTION
See https://github.com/rtomayko/tilt/blob/master/docs/TEMPLATES.md#escape_html--truefalse

Supersedes #350