### PR TITLE
Fix markdown documentation 404

### DIFF
--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -508,7 +508,7 @@ Kramdown and Maruku don't support this option.
 
 ### See also
 
- * [Markdown Syntax Documentation](http://daringfireball.net/projects/markdown/syntax/)
+ * [Markdown Syntax Documentation](http://daringfireball.net/projects/markdown/syntax)
 
 <a name='rdiscount'></a>
 RDiscount (`markdown`, `md`, `mkd`)


### PR DESCRIPTION
For whatever reason, the Daring Fireball documentation site doesn't load if the URL contains a trailing slash. 

I'm sure this is a simple configuration on their webserver end to make, but for now new Tilt users looking to view the documentation will be presented with a 404 page.

This PR fixes that by removing the trailing slash.

Before: https://daringfireball.net/projects/markdown/syntax/
After: https://daringfireball.net/projects/markdown/syntax