### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/tilt.gemspec
+++ b/tilt.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
 
   s.executables = ['tilt']
 
-  s.homepage = "http://github.com/rtomayko/tilt/"
+  s.homepage = "https://github.com/rtomayko/tilt/"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Tilt", "--main", "Tilt"]
   s.require_paths = %w[lib]
   s.rubygems_version = '1.1.1'


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/tilt or some tools or APIs that use the gem's metadata.