### PR TITLE
Fix Ruby 3.0 compatibility.

### DIFF
--- a/lib/tilt/csv.rb
+++ b/lib/tilt/csv.rb
@@ -50,7 +50,7 @@ module Tilt
 
     def precompiled_template(locals)
       <<-RUBY
-        #{@outvar} = #{self.class.engine}.generate(#{options}) do |csv|
+        #{@outvar} = #{self.class.engine}.generate(**#{options}) do |csv|
           #{data}
         end
       RUBY


### PR DESCRIPTION
This fixes issues such as:

~~~
  1) Error:
CSVTemplateTest#test_compiles_and_evaluates_the_template_on_render:
TypeError: no implicit conversion of Hash into String
    /usr/share/ruby/csv.rb:1273:in `initialize'
    /usr/share/ruby/csv.rb:1273:in `new'
    /usr/share/ruby/csv.rb:1273:in `generate'
    (__TEMPLATE__):in `__tilt_920'
    /builddir/build/BUILD/tilt-2.0.10/usr/share/gems/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `call'
    /builddir/build/BUILD/tilt-2.0.10/usr/share/gems/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `evaluate'
    /builddir/build/BUILD/tilt-2.0.10/usr/share/gems/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'
    /builddir/build/BUILD/tilt-2.0.10/usr/share/gems/gems/tilt-2.0.10/test/tilt_csv_test.rb:15:in `block in <class:CSVTemplateTest>'
~~~