### PR TITLE
Allow all options and extensions available in CommonMarker

### DIFF
--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -463,9 +463,7 @@ Markdown formatted texts are converted to HTML with one of these libraries:
   * Kramdown - `Tilt::KramdownTemplate`
   * Pandoc - `Tilt::PandocTemplate`
   * Maruku - `Tilt::MarukuTemplate`
-
-Tilt will use fallback mode (as documented in the README) for determining which
-library to use. RDiscount has highest priority - Maruku has lowest.
+  * CommonMarker - `Tilt::CommonMarkerTemplate`
 
 ### Example
 

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -9,21 +9,31 @@ module Tilt
       :smartypants => :SMART
     }
     PARSE_OPTIONS = [
+      :FOOTNOTES,
+      :LIBERAL_HTML_TAG,
       :SMART,
       :smartypants,
+      :STRIKETHROUGH_DOUBLE_TILDE,
+      :UNSAFE,
+      :VALIDATE_UTF8,
     ].freeze
     RENDER_OPTIONS = [
+      :FOOTNOTES,
+      :FULL_INFO_STRING,
       :GITHUB_PRE_LANG,
       :HARDBREAKS,
       :NOBREAKS,
-      :SAFE,
+      :SAFE, # Removed in v0.18.0 (2018-10-17)
       :SOURCEPOS,
+      :TABLE_PREFER_STYLE_ATTRIBUTES,
+      :UNSAFE,
     ].freeze
     EXTENSIONS = [
       :autolink,
       :strikethrough,
       :table,
       :tagfilter,
+      :tasklist,
     ].freeze
 
     def extensions

--- a/test/tilt_commonmarkertemplate_test.rb
+++ b/test/tilt_commonmarkertemplate_test.rb
@@ -22,6 +22,37 @@ begin
       assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
     end
 
+    test 'Renders unsafe HTML when :UNSAFE is set' do
+      template = Tilt::CommonMarkerTemplate.new(UNSAFE: true) do |_t|
+        <<~MARKDOWN
+          <div class="alert alert-info full-width">
+            <h5 class="card-title">TL;DR</h5>
+            <p>This is an unsafe HTML block</p>
+          </div>
+
+          And then some **other** Markdown
+        MARKDOWN
+      end
+
+      expected = <<~EXPECTED_HTML
+        <div class="alert alert-info full-width">
+          <h5 class="card-title">TL;DR</h5>
+          <p>This is an unsafe HTML block</p>
+        </div>
+        <p>And then some <strong>other</strong> Markdown</p>
+      EXPECTED_HTML
+
+      assert_match(expected, template.render)
+    end
+
+    test "All CommonMarker parse options are available to users" do
+      assert_empty(CommonMarker::Config::Parse.keys - (Tilt::CommonMarkerTemplate::PARSE_OPTIONS + [:DEFAULT]))
+    end
+
+    test "All CommonMarker render options are available to users" do
+      assert_empty(CommonMarker::Config::Render.keys - (Tilt::CommonMarkerTemplate::RENDER_OPTIONS + [:DEFAULT]))
+    end
+
   end
 rescue LoadError
   warn "Tilt::CommonMarkerTemplate (disabled)"


### PR DESCRIPTION
Updated to match v0.21.2: https://github.com/gjtorikian/commonmarker