### PR TITLE
Add Tilt::EmacsOrg support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ These template engines ship with their own Tilt integration:
 | Embedded CoffeeScript |                  | sprockets           |
 | JST                   |                  | sprockets           |
 | Org-mode              | .org             | org-ruby (>= 0.6.2) |
+| Emacs Org             | .org             | tilt-emacs_org      |
 | Handlebars            | .hbs, handlebars | tilt-handlebars     |
 | Jbuilder              | .jbuilder        | tilt-jbuilder       |
 

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -161,6 +161,7 @@ module Tilt
   register_lazy 'Slim::Template',            'slim',            'slim'
   register_lazy 'Tilt::HandlebarsTemplate',  'tilt/handlebars', 'handlebars', 'hbs'
   register_lazy 'Tilt::OrgTemplate',         'org-ruby',        'org'
+  register_lazy 'Tilt::EmacsOrgTemplate',    'tilt/emacs_org',  'org'
   register_lazy 'Opal::Processor',           'opal',            'opal', 'rb'
   register_lazy 'Tilt::JbuilderTemplate',    'tilt/jbuilder',   'jbuilder'
 end


### PR DESCRIPTION
With the `tilt-emacs_org` gem