### PR TITLE
Remove Hakiri badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Tilt [![Build Status](https://secure.travis-ci.org/rtomayko/tilt.svg)](http://travis-ci.org/rtomayko/tilt) [![Inline docs](http://inch-ci.org/github/rtomayko/tilt.svg)](http://inch-ci.org/github/rtomayko/tilt) [![Security](https://hakiri.io/github/rtomayko/tilt/master.svg)](https://hakiri.io/github/rtomayko/tilt/master)
+Tilt [![Build Status](https://secure.travis-ci.org/rtomayko/tilt.svg)](http://travis-ci.org/rtomayko/tilt) [![Inline docs](http://inch-ci.org/github/rtomayko/tilt.svg)](http://inch-ci.org/github/rtomayko/tilt)
 ====
 
 **NOTE** The following file documents the current release of Tilt (2.0). See


### PR DESCRIPTION
[Hakiri](https://hakiri.io/) was sunset on January 31, 2022.