### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ desc 'Run tests (default)'
 Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/*_test.rb']
   t.ruby_opts = ['-Itest']
-  t.ruby_opts << '-rrubygems' if defined? Gem
   t.warning = false
 end
 
@@ -42,11 +41,6 @@ task :man do
 end
 
 # PACKAGING =================================================================
-
-begin
-  require 'rubygems'
-rescue LoadError
-end
 
 if defined?(Gem)
   SPEC = eval(File.read('tilt.gemspec'))

--- a/lib/tilt/csv.rb
+++ b/lib/tilt/csv.rb
@@ -1,10 +1,5 @@
 require 'tilt/template'
-
-if RUBY_VERSION >= '1.9.0'
-  require 'csv'
-else
-  require 'fastercsv'
-end
+require 'csv'
 
 module Tilt
 
@@ -36,21 +31,13 @@ module Tilt
   class CSVTemplate < Template
     self.default_mime_type = 'text/csv'
 
-    def self.engine
-      if RUBY_VERSION >= '1.9.0' && defined? ::CSV
-        ::CSV
-      elsif defined? ::FasterCSV
-        ::FasterCSV 
-      end
-    end
-
     def prepare
       @outvar = options.delete(:outvar) || '_csvout'
     end
 
     def precompiled_template(locals)
       <<-RUBY
-        #{@outvar} = #{self.class.engine}.generate(**#{options}) do |csv|
+        #{@outvar} = CSV.generate(**#{options}) do |csv|
           #{data}
         end
       RUBY

--- a/lib/tilt/erb.rb
+++ b/lib/tilt/erb.rb
@@ -52,11 +52,9 @@ module Tilt
 
     # ERB generates a line to specify the character coding of the generated
     # source in 1.9. Account for this in the line offset.
-    if RUBY_VERSION >= '1.9.0'
-      def precompiled(locals)
-        source, offset = super
-        [source, offset + 1]
-      end
+    def precompiled(locals)
+      source, offset = super
+      [source, offset + 1]
     end
   end
 end

--- a/lib/tilt/erubis.rb
+++ b/lib/tilt/erubis.rb
@@ -33,11 +33,9 @@ module Tilt
 
     # Erubis doesn't have ERB's line-off-by-one under 1.9 problem.
     # Override and adjust back.
-    if RUBY_VERSION >= '1.9.0'
-      def precompiled(locals)
-        source, offset = super
-        [source, offset - 1]
-      end
+    def precompiled(locals)
+      source, offset = super
+      [source, offset - 1]
     end
   end
 end

--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -2,16 +2,12 @@ require 'thread'
 
 module Tilt
   # @private
-  TOPOBJECT = if RUBY_VERSION >= '2.0'
-    # @private
-    module CompiledTemplates
-      self
-    end
-  elsif RUBY_VERSION >= '1.9'
-    BasicObject
-  else
-    Object
+  module CompiledTemplates
   end
+
+  # @private
+  TOPOBJECT = CompiledTemplates
+
   # @private
   LOCK = Mutex.new
 
@@ -172,11 +168,7 @@ module Tilt
       when Object
         method = compiled_method(locals_keys, Module === scope ? scope : scope.class)
       else
-        if RUBY_VERSION >= '2'
-          method = compiled_method(locals_keys, CLASS_METHOD.bind(scope).call)
-        else
-          method = compiled_method(locals_keys, Object)
-        end
+        method = compiled_method(locals_keys, CLASS_METHOD.bind(scope).call)
       end
       method.bind(scope).call(locals, &block)
     end

--- a/test/tilt_radiustemplate_test.rb
+++ b/test/tilt_radiustemplate_test.rb
@@ -4,9 +4,9 @@ require 'tilt'
 begin
   require 'tilt/radius'
 
-  # Disable radius tests under Ruby versions >= 1.9.1 since it's still buggy.
+  # Disable radius tests for old Radius versions since it's still buggy.
   # Remove when fixed upstream.
-  raise LoadError if RUBY_VERSION >= "1.9.1" and Radius.version < "0.7"
+  raise LoadError if Radius.version < "0.7"
 
   class RadiusTemplateTest < Minitest::Test
     test "registered for '.radius' files" do

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -224,11 +224,9 @@ class TiltTemplateTest < Minitest::Test
     assert_equal "Hey Joe!", inst.render(BasicObject.new){ 'Joe' }
   end
 
-  if RUBY_VERSION >= '2'
-    test "template which accesses a BasicObject constant" do
-      inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{CONSTANT}!' }
-      assert_equal "Hey Bob!", inst.render(BasicPerson.new("Joe"))
-    end
+  test "template which accesses a BasicObject constant" do
+    inst = SourceGeneratingMockTemplate.new { |t| 'Hey #{CONSTANT}!' }
+    assert_equal "Hey Bob!", inst.render(BasicPerson.new("Joe"))
   end
 
   test "template which accesses a constant using BasicObject scope class" do

--- a/tilt.gemspec
+++ b/tilt.gemspec
@@ -1,7 +1,4 @@
 Gem::Specification.new do |s|
-  s.specification_version = 2 if s.respond_to? :specification_version=
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-
   s.name = 'tilt'
   s.version = '2.0.11'
   s.date = '2022-07-22'
@@ -64,5 +61,5 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/rtomayko/tilt/"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Tilt", "--main", "Tilt"]
   s.require_paths = %w[lib]
-  s.rubygems_version = '1.1.1'
+  s.required_ruby_version = ">= 2.0"
 end


### PR DESCRIPTION
At least some parts of tilt now require Ruby 2.0.0 (at least since
b1329a8a4883f0e08b12f1e639922105d3234438).

Remove specification_version, as rubygems states:

"Do not set this, it is set automatically when the gem is packaged."

Remove required_rubygems_version, a requirement of >= 0 is the same
as no requirement.

Remove rubygems version, as it is wrong and has no effect.