### PR TITLE
Add livescript extension for LiveScript and remove Opal support

### DIFF
--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -140,7 +140,7 @@ module Tilt
   register_lazy :HamlTemplate,         'tilt/haml',      'haml'
   register_lazy :LessTemplate,         'tilt/less',      'less'
   register_lazy :LiquidTemplate,       'tilt/liquid',    'liquid'
-  register_lazy :LiveScriptTemplate,   'tilt/livescript','ls'
+  register_lazy :LiveScriptTemplate,   'tilt/livescript','ls', 'livescript'
   register_lazy :MarkabyTemplate,      'tilt/markaby',   'mab'
   register_lazy :NokogiriTemplate,     'tilt/nokogiri',  'nokogiri'
   register_lazy :PlainTemplate,        'tilt/plain',     'html'
@@ -162,6 +162,5 @@ module Tilt
   register_lazy 'Tilt::HandlebarsTemplate',  'tilt/handlebars', 'handlebars', 'hbs'
   register_lazy 'Tilt::OrgTemplate',         'org-ruby',        'org'
   register_lazy 'Tilt::EmacsOrgTemplate',    'tilt/emacs_org',  'org'
-  register_lazy 'Opal::Processor',           'opal',            'opal', 'rb'
   register_lazy 'Tilt::JbuilderTemplate',    'tilt/jbuilder',   'jbuilder'
 end


### PR DESCRIPTION
Remove support for external opal, since opal changed the API.

Fixes #323
Fixes #359