### PR TITLE
Test cleanups

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,3 @@
-require 'bundler'
-Bundler.setup
-
 require 'rake/testtask'
 task :default => [:test]
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ task :default => [:test]
 desc 'Run tests (default)'
 Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/*_test.rb']
-  t.ruby_opts = ['-Itest']
   t.warning = false
 end
 

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -1,5 +1,5 @@
-require 'tilt/mapping'
-require 'tilt/template'
+require_relative 'tilt/mapping'
+require_relative 'tilt/template'
 
 # Namespace for Tilt. This module is not intended to be included anywhere.
 module Tilt

--- a/lib/tilt/erb.rb
+++ b/lib/tilt/erb.rb
@@ -20,11 +20,18 @@ module Tilt
 
     def prepare
       @outvar = options[:outvar] || self.class.default_output_variable
-      options[:trim] = '<>' if !(options[:trim] == false) && (options[:trim].nil? || options[:trim] == true)
-      @engine = if SUPPORTS_KVARGS
-        ::ERB.new(data, trim_mode: options[:trim], eoutvar: @outvar)
+      trim = case options[:trim]
+      when false
+        nil
+      when nil, true
+        '<>'
       else
-        ::ERB.new(data, options[:safe], options[:trim], @outvar)
+        options[:trim]
+      end
+      @engine = if SUPPORTS_KVARGS
+        ::ERB.new(data, trim_mode: trim, eoutvar: @outvar)
+      else
+        ::ERB.new(data, options[:safe], trim, @outvar)
       end
     end
 

--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -1,5 +1,3 @@
-require 'thread'
-
 module Tilt
   # @private
   module CompiledTemplates

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 
 require_relative  '../lib/tilt'
+
+ENV['MT_NO_PLUGINS'] = '1' # Work around stupid autoloading of plugins
 require 'minitest/autorun'
 require 'minitest/mock'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 
+require_relative  '../lib/tilt'
 require 'minitest/autorun'
 require 'minitest/mock'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,5 @@
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 
-require 'bundler'
-Bundler.setup
-
 require 'minitest/autorun'
 require 'minitest/mock'
 

--- a/test/tilt_asciidoctor_test.rb
+++ b/test/tilt_asciidoctor_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/asciidoc'

--- a/test/tilt_babeltemplate.rb
+++ b/test/tilt_babeltemplate.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/babel'

--- a/test/tilt_blueclothtemplate_test.rb
+++ b/test/tilt_blueclothtemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/bluecloth'

--- a/test/tilt_buildertemplate_test.rb
+++ b/test/tilt_buildertemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/builder'

--- a/test/tilt_cache_test.rb
+++ b/test/tilt_cache_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 class TiltCacheTest < Minitest::Test
   setup { @cache = Tilt::Cache.new }

--- a/test/tilt_coffeescripttemplate_test.rb
+++ b/test/tilt_coffeescripttemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/coffee'

--- a/test/tilt_commonmarkertemplate_test.rb
+++ b/test/tilt_commonmarkertemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/commonmarker'

--- a/test/tilt_compilesite_test.rb
+++ b/test/tilt_compilesite_test.rb
@@ -1,6 +1,4 @@
-require 'test_helper'
-require 'tilt'
-require 'thread'
+require_relative 'test_helper'
 
 class CompileSiteTest < Minitest::Test
   def setup

--- a/test/tilt_creoletemplate_test.rb
+++ b/test/tilt_creoletemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/creole'

--- a/test/tilt_csv_test.rb
+++ b/test/tilt_csv_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/csv'

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -38,7 +38,9 @@ class ERBTemplateTest < Minitest::Test
   end
 
   test "exposing the buffer to the template by default" do
+    verbose = $VERBOSE
     begin
+      $VERBOSE = nil
       Tilt::ERBTemplate.default_output_variable = '@_out_buf'
       template = Tilt::ERBTemplate.new { '<% self.exposed_buffer = @_out_buf %>hey' }
       scope = MockOutputVariableScope.new
@@ -47,6 +49,7 @@ class ERBTemplateTest < Minitest::Test
       assert_equal scope.exposed_buffer, 'hey'
     ensure
       Tilt::ERBTemplate.default_output_variable = '_erbout'
+      $VERBOSE = verbose
     end
   end
 

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -1,6 +1,4 @@
-# coding: utf-8
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 require 'tilt/erb'
 require 'tempfile'
 

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -204,14 +204,13 @@ class CompiledERBTemplateTest < Minitest::Test
     assert_equal "\nhello\n", template.render(Scope.new)
   end
 
-  test "encoding with magic comment" do
+  test "encoding with source_encoding" do
     f = Tempfile.open("template")
-    f.puts('<%# coding: UTF-8 %>')
     f.puts('ふが <%= @hoge %>')
     f.close()
     @hoge = "ほげ"
-    erb = Tilt::ERBTemplate.new(f.path)
-    3.times { erb.render(self) }
+    erb = Tilt::ERBTemplate.new(f.path){File.read(f.path, encoding: 'UTF-8')}
+    3.times { assert_equal 'UTF-8', erb.render(self).encoding.to_s }
     f.delete
   end
 
@@ -221,7 +220,7 @@ class CompiledERBTemplateTest < Minitest::Test
     f.close()
     @hoge = "ほげ"
     erb = Tilt::ERBTemplate.new(f.path, :default_encoding => 'UTF-8')
-    3.times { erb.render(self) }
+    3.times { assert_equal 'UTF-8', erb.render(self).encoding.to_s }
     f.delete
   end
 end

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -56,7 +56,7 @@ class ERBTemplateTest < Minitest::Test
   end
 
   test "backtrace file and line reporting without locals" do
-    data = File.read(__FILE__).split("\n__END__\n").last
+    data = File.read(__FILE__, :encoding=>'UTF-8').split("\n__END__\n").last
     fail unless data[0] == ?<
     template = Tilt::ERBTemplate.new('test.erb', 11) { data }
     begin
@@ -72,7 +72,7 @@ class ERBTemplateTest < Minitest::Test
   end
 
   test "backtrace file and line reporting with locals" do
-    data = File.read(__FILE__).split("\n__END__\n").last
+    data = File.read(__FILE__, :encoding=>'UTF-8').split("\n__END__\n").last
     fail unless data[0] == ?<
     template = Tilt::ERBTemplate.new('test.erb', 1) { data }
     begin
@@ -158,7 +158,7 @@ class CompiledERBTemplateTest < Minitest::Test
   end
 
   test "backtrace file and line reporting without locals" do
-    data = File.read(__FILE__).split("\n__END__\n").last
+    data = File.read(__FILE__, encoding: 'UTF-8').split("\n__END__\n").last
     fail unless data[0] == ?<
     template = Tilt::ERBTemplate.new('test.erb', 11) { data }
     begin
@@ -174,7 +174,7 @@ class CompiledERBTemplateTest < Minitest::Test
   end
 
   test "backtrace file and line reporting with locals" do
-    data = File.read(__FILE__).split("\n__END__\n").last
+    data = File.read(__FILE__, encoding: 'UTF-8').split("\n__END__\n").last
     fail unless data[0] == ?<
     template = Tilt::ERBTemplate.new('test.erb') { data }
     begin

--- a/test/tilt_erubistemplate_test.rb
+++ b/test/tilt_erubistemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/erubis'

--- a/test/tilt_erubitemplate_test.rb
+++ b/test/tilt_erubitemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/erubi'

--- a/test/tilt_etannitemplate_test.rb
+++ b/test/tilt_etannitemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 require 'tilt/etanni'
 
 class EtanniTemplateTest < Minitest::Test

--- a/test/tilt_hamltemplate_test.rb
+++ b/test/tilt_hamltemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   class ::MockError < NameError

--- a/test/tilt_kramdown_test.rb
+++ b/test/tilt_kramdown_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/kramdown'

--- a/test/tilt_lesstemplate_test.rb
+++ b/test/tilt_lesstemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'pathname'

--- a/test/tilt_liquidtemplate_test.rb
+++ b/test/tilt_liquidtemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/liquid'

--- a/test/tilt_livescripttemplate_test.rb
+++ b/test/tilt_livescripttemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/livescript'

--- a/test/tilt_mapping_test.rb
+++ b/test/tilt_mapping_test.rb
@@ -1,6 +1,4 @@
-require 'test_helper'
-require 'tilt'
-require 'tilt/mapping'
+require_relative 'test_helper'
 
 module Tilt
 
@@ -100,8 +98,13 @@ module Tilt
       end
 
       test "doesn't require when the template class is autoloaded, and then defined" do
-        Object.autoload :MyTemplate, 'mytemplate'
-        did_load = require 'mytemplate'
+        $LOAD_PATH << __dir__
+        begin
+          Object.autoload :MyTemplate, 'mytemplate'
+          did_load = require 'mytemplate'
+        ensure
+          $LOAD_PATH.delete(__dir__)
+        end
         assert did_load, "mytemplate wasn't freshly required"
 
         req = proc do |file|

--- a/test/tilt_markaby_test.rb
+++ b/test/tilt_markaby_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/markaby'

--- a/test/tilt_markdown_test.rb
+++ b/test/tilt_markdown_test.rb
@@ -1,6 +1,4 @@
-# coding: UTF-8
-require 'tilt'
-require 'test_helper'
+require_relative 'test_helper'
 
 begin
 require 'nokogiri'

--- a/test/tilt_marukutemplate_test.rb
+++ b/test/tilt_marukutemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/maruku'

--- a/test/tilt_metadata_test.rb
+++ b/test/tilt_metadata_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt/template'
+require_relative 'test_helper'
 
 module Tilt
   class TemplateMetadataTest < Minitest::Test

--- a/test/tilt_nokogiritemplate_test.rb
+++ b/test/tilt_nokogiritemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/nokogiri'

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -1,7 +1,4 @@
-# encoding: utf-8
-
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/pandoc'

--- a/test/tilt_prawntemplate_test.rb
+++ b/test/tilt_prawntemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/prawn'

--- a/test/tilt_radiustemplate_test.rb
+++ b/test/tilt_radiustemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/radius'

--- a/test/tilt_rdiscounttemplate_test.rb
+++ b/test/tilt_rdiscounttemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/rdiscount'

--- a/test/tilt_rdoctemplate_test.rb
+++ b/test/tilt_rdoctemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/rdoc'

--- a/test/tilt_redcarpettemplate_test.rb
+++ b/test/tilt_redcarpettemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/redcarpet'

--- a/test/tilt_redclothtemplate_test.rb
+++ b/test/tilt_redclothtemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/redcloth'

--- a/test/tilt_rstpandoctemplate_test.rb
+++ b/test/tilt_rstpandoctemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/rst-pandoc'

--- a/test/tilt_sasstemplate_test.rb
+++ b/test/tilt_sasstemplate_test.rb
@@ -10,12 +10,12 @@ begin
 
     test "compiles and evaluates the template on #render" do
       template = Tilt::SassTemplate.new({ style: :compressed }) { |t| "#main\n  background-color: #0000f1" }
-      assert_equal "#main{background-color:#0000f1}", template.render
+      assert_equal "#main{background-color:#0000f1}", template.render.chomp
     end
 
     test "can be rendered more than once" do
       template = Tilt::SassTemplate.new({ style: :compressed }) { |t| "#main\n  background-color: #0000f1" }
-      3.times { assert_equal "#main{background-color:#0000f1}", template.render }
+      3.times { assert_equal "#main{background-color:#0000f1}", template.render.chomp }
     end
   end
 
@@ -26,12 +26,12 @@ begin
 
     test "compiles and evaluates the template on #render" do
       template = Tilt::ScssTemplate.new({ style: :compressed }) { |t| "#main {\n  background-color: #0000f1;\n}" }
-      assert_equal "#main{background-color:#0000f1}", template.render
+      assert_equal "#main{background-color:#0000f1}", template.render.chomp
     end
 
     test "can be rendered more than once" do
       template = Tilt::ScssTemplate.new({ style: :compressed }) { |t| "#main {\n  background-color: #0000f1;\n}" }
-      3.times { assert_equal "#main{background-color:#0000f1}", template.render }
+      3.times { assert_equal "#main{background-color:#0000f1}", template.render.chomp }
     end
   end
 

--- a/test/tilt_sasstemplate_test.rb
+++ b/test/tilt_sasstemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/sass'

--- a/test/tilt_sigil_test.rb
+++ b/test/tilt_sigil_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 require 'tilt/sigil'
 
 system('sigil -v')

--- a/test/tilt_stringtemplate_test.rb
+++ b/test/tilt_stringtemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 require 'tilt/string'
 
 class StringTemplateTest < Minitest::Test

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -306,6 +306,7 @@ class TiltTemplateTest < Minitest::Test
     end
 
     test "uses the template from the generated source code" do
+      Encoding.default_external = 'UTF-8'
       tmpl = "ふが"
       code = tmpl.inspect.encode('Shift_JIS')
       inst = DynamicMockTemplate.new(:code => code) { '' }
@@ -315,6 +316,7 @@ class TiltTemplateTest < Minitest::Test
     end
 
     test "uses the magic comment from the generated source code" do
+      Encoding.default_external = 'UTF-8'
       tmpl = "ふが"
       code = ("# coding: Shift_JIS\n" + tmpl.inspect).encode('Shift_JIS')
       # Set it to an incorrect encoding

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -1,8 +1,6 @@
-# coding: utf-8
-require 'test_helper'
-require 'tilt'
-require 'tilt/template'
+require_relative 'test_helper'
 require 'tempfile'
+require 'pathname'
 
 class TiltTemplateTest < Minitest::Test
 

--- a/test/tilt_test.rb
+++ b/test/tilt_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 class TiltTest < Minitest::Test
   class MockTemplate

--- a/test/tilt_typescript_test.rb
+++ b/test/tilt_typescript_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/typescript'

--- a/test/tilt_wikiclothtemplate_test.rb
+++ b/test/tilt_wikiclothtemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/wikicloth'

--- a/test/tilt_yajltemplate_test.rb
+++ b/test/tilt_yajltemplate_test.rb
@@ -1,5 +1,4 @@
-require 'test_helper'
-require 'tilt'
+require_relative 'test_helper'
 
 begin
   require 'tilt/yajl'


### PR DESCRIPTION
This series of commits allow me to run the tests locally with no failures or warnings (other than those for template engines not yet installed).

It makes it  simple to run individual test files via `ruby test/tilt_*_test.rb`

This fixes tests errors with certain versions of sass, and errors when the default external encoding is not UTF-8.

I found that one test is incorrect, testing for something that Tilt doesn't actually support (magic comment extraction from template source code), so I updated the test to test that it works with source encoding.  Tilt only supports magic comment extraction from generated ruby code for precompiled templates.

Please see the individual commit messages for more detail.