### PR TITLE
Remove more Ruby <2 compatibility code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,12 +45,8 @@ group :secondary do
   gem 'liquid'
   gem 'maruku'
   gem 'pandoc-ruby'
-
-  if RUBY_VERSION > '1.9.3'
-    gem 'prawn', '>= 2.0.0'
-    gem 'pdf-reader', '~> 1.3.3'
-  end
-
+  gem 'prawn', '>= 2.0.0'
+  gem 'pdf-reader', '~> 1.3.3'
   gem 'nokogiri'
 
   # Both rdiscount and bluecloth embeds Discount and loading

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,22 @@ class Minitest::Test
     RUBY_PLATFORM == "java"
   end
 
+  def with_default_encoding(encoding)
+    prev = Encoding.default_external
+
+    begin
+      Encoding.default_external = encoding
+
+      yield
+    ensure
+      Encoding.default_external = prev
+    end
+  end
+
+  def with_utf8_default_encoding(&block)
+    with_default_encoding('UTF-8', &block)
+  end
+
 private
 
   def self.context_name(name)

--- a/test/tilt_babeltemplate.rb
+++ b/test/tilt_babeltemplate.rb
@@ -17,13 +17,17 @@ begin
     end
 
     test "basic ES6 features" do
-      template = Tilt::BabelTemplate.new { "square = (x) => x * x" }
-      assert_match "function", template.render
+      with_utf8_default_encoding do
+        template = Tilt::BabelTemplate.new { "square = (x) => x * x" }
+        assert_match "function", template.render
+      end
     end
 
     test "JSX support" do
-      template = Tilt::BabelTemplate.new { "<Awesome ness={true} />" }
-      assert_match "React.createElement", template.render
+      with_utf8_default_encoding do
+        template = Tilt::BabelTemplate.new { "<Awesome ness={true} />" }
+        assert_match "React.createElement", template.render
+      end
     end
   end
 rescue LoadError => boom

--- a/test/tilt_markdown_test.rb
+++ b/test/tilt_markdown_test.rb
@@ -22,7 +22,7 @@ module MarkdownTests
 
   def nrender(text, options = {})
     html = render(text, options)
-    html.encode!("UTF-8") if html.respond_to?(:encode)
+    html.encode!("UTF-8")
     normalize(html)
   end
 

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -265,8 +265,6 @@ class TiltTemplateTest < Minitest::Test
   end
 
   if ''.respond_to?(:encoding)
-    original_encoding = Encoding.default_external
-
     setup do
       @file = Tempfile.open('template')
       @file.puts "stuff"
@@ -275,63 +273,72 @@ class TiltTemplateTest < Minitest::Test
     end
 
     teardown do
-      Encoding.default_external = original_encoding
-      Encoding.default_internal = nil
       @file.delete
     end
 
     test "reading from file assumes default external encoding" do
-      Encoding.default_external = 'Big5'
-      inst = MockTemplate.new(@template)
-      assert_equal 'Big5', inst.data.encoding.to_s
+      with_default_encoding('Big5') do
+        inst = MockTemplate.new(@template)
+        assert_equal 'Big5', inst.data.encoding.to_s
+      end
     end
 
     test "reading from file with a :default_encoding overrides default external" do
-      Encoding.default_external = 'Big5'
-      inst = MockTemplate.new(@template, :default_encoding => 'GBK')
-      assert_equal 'GBK', inst.data.encoding.to_s
+      with_default_encoding('Big5') do
+        inst = MockTemplate.new(@template, :default_encoding => 'GBK')
+        assert_equal 'GBK', inst.data.encoding.to_s
+      end
     end
 
     test "reading from file with default_internal set does no transcoding" do
-      Encoding.default_internal = 'utf-8'
-      Encoding.default_external = 'Big5'
-      inst = MockTemplate.new(@template)
-      assert_equal 'Big5', inst.data.encoding.to_s
+      begin
+        Encoding.default_internal = 'utf-8'
+        with_default_encoding('Big5') do
+          inst = MockTemplate.new(@template)
+          assert_equal 'Big5', inst.data.encoding.to_s
+        end
+      ensure
+        Encoding.default_internal = nil
+      end
     end
 
     test "using provided template data verbatim when given as string" do
-      Encoding.default_internal = 'Big5'
-      inst = MockTemplate.new(@template) { "blah".force_encoding('GBK') }
-      assert_equal 'GBK', inst.data.encoding.to_s
+      with_default_encoding('Big5') do
+        inst = MockTemplate.new(@template) { "blah".force_encoding('GBK') }
+        assert_equal 'GBK', inst.data.encoding.to_s
+      end
     end
 
     test "uses the template from the generated source code" do
-      Encoding.default_external = 'UTF-8'
-      tmpl = "ふが"
-      code = tmpl.inspect.encode('Shift_JIS')
-      inst = DynamicMockTemplate.new(:code => code) { '' }
-      res = inst.render
-      assert_equal 'Shift_JIS', res.encoding.to_s
-      assert_equal tmpl, res.encode(tmpl.encoding)
+      with_utf8_default_encoding do
+        tmpl = "ふが"
+        code = tmpl.inspect.encode('Shift_JIS')
+        inst = DynamicMockTemplate.new(:code => code) { '' }
+        res = inst.render
+        assert_equal 'Shift_JIS', res.encoding.to_s
+        assert_equal tmpl, res.encode(tmpl.encoding)
+      end
     end
 
     test "uses the magic comment from the generated source code" do
-      Encoding.default_external = 'UTF-8'
-      tmpl = "ふが"
-      code = ("# coding: Shift_JIS\n" + tmpl.inspect).encode('Shift_JIS')
-      # Set it to an incorrect encoding
-      code.force_encoding('UTF-8')
+      with_utf8_default_encoding do
+        tmpl = "ふが"
+        code = ("# coding: Shift_JIS\n" + tmpl.inspect).encode('Shift_JIS')
+        # Set it to an incorrect encoding
+        code.force_encoding('UTF-8')
 
-      inst = DynamicMockTemplate.new(:code => code) { '' }
-      res = inst.render
-      assert_equal 'Shift_JIS', res.encoding.to_s
-      assert_equal tmpl, res.encode(tmpl.encoding)
+        inst = DynamicMockTemplate.new(:code => code) { '' }
+        res = inst.render
+        assert_equal 'Shift_JIS', res.encoding.to_s
+        assert_equal tmpl, res.encode(tmpl.encoding)
+      end
     end
 
     test "uses #default_encoding instead of default_external" do
-      Encoding.default_external = 'Big5'
-      inst = UTF8Template.new(@template)
-      assert_equal 'UTF-8', inst.data.encoding.to_s
+      with_default_encoding('Big5') do
+        inst = UTF8Template.new(@template)
+        assert_equal 'UTF-8', inst.data.encoding.to_s
+      end
     end
 
     test "uses #default_encoding instead of current encoding" do


### PR DESCRIPTION
Also, DRY up some test code using with_default_encoding and
with_utf8_default_encoding helper methods, instead of updating
default encodings in setup/teardown blocks.  This makes sure
only the specific tests that need default encodings have them
set.