### PR TITLE
Minor fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 group :primary do
   gem 'builder'
   gem 'haml', '>= 4'
-  gem 'erubis'
+  gem 'erubi'
   gem 'markaby'
 
   case ENV['SASS_IMPLEMENTATION']
@@ -25,7 +25,6 @@ group :primary do
     gem 'sass-embedded'
   end
 
-  gem 'less'
   gem 'coffee-script'
   gem 'livescript'
   gem 'babel-transpiler'
@@ -38,6 +37,7 @@ end
 
 group :secondary do
   gem 'creole'
+  gem 'erubis'
   gem 'kramdown'
   gem 'rdoc'
   gem 'radius'
@@ -46,8 +46,11 @@ group :secondary do
   gem 'maruku'
   gem 'pandoc-ruby'
   gem 'prawn', '>= 2.0.0'
-  gem 'pdf-reader', '~> 1.3.3'
+  gem 'pdf-reader'
   gem 'nokogiri'
+
+  gem 'less'
+  gem 'therubyracer'
 
   # Both rdiscount and bluecloth embeds Discount and loading
   # both at the same time causes strange issues.

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,12 @@ group :secondary do
   gem 'pdf-reader'
   gem 'nokogiri'
 
+  if RUBY_VERSION >= '3.1'
+    # Was default library, now bundled gem.
+    # Needed by prawn tests.
+    gem 'matrix'
+  end
+
   # Both rdiscount and bluecloth embeds Discount and loading
   # both at the same time causes strange issues.
   discount_gem = ENV["DISCOUNT_GEM"] || "rdiscount"

--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,6 @@ group :secondary do
   gem 'pdf-reader'
   gem 'nokogiri'
 
-  gem 'less'
-  gem 'therubyracer'
-
   # Both rdiscount and bluecloth embeds Discount and loading
   # both at the same time causes strange issues.
   discount_gem = ENV["DISCOUNT_GEM"] || "rdiscount"

--- a/lib/tilt/rst-pandoc.rb
+++ b/lib/tilt/rst-pandoc.rb
@@ -1,5 +1,5 @@
 require 'tilt/template'
-require 'pandoc'
+require_relative 'pandoc'
 
 module Tilt
   # Pandoc reStructuredText implementation. See:

--- a/test/tilt_markdown_test.rb
+++ b/test/tilt_markdown_test.rb
@@ -54,8 +54,10 @@ _MarkdownTests = Module.new do
   end
 
   it "should use smart quotes if :smartypants => true" do
-    html = nrender 'Hello "World"', :smartypants => true
-    assert_equal '<p>Hello “World”</p>', html
+    with_utf8_default_encoding do
+      html = nrender 'Hello "World"', :smartypants => true
+      assert_equal '<p>Hello “World”</p>', html
+    end
   end
 
   it "should not use smartypants by default" do

--- a/test/tilt_pandoctemplate_test.rb
+++ b/test/tilt_pandoctemplate_test.rb
@@ -15,8 +15,10 @@ begin
     end
 
     it "smartypants when :smartypants is set" do
-      template = Tilt::PandocTemplate.new(:smartypants => true) { |t| "OKAY -- 'Smarty Pants'" }
-      assert_equal "<p>OKAY – ‘Smarty Pants’</p>", template.render
+      with_utf8_default_encoding do
+        template = Tilt::PandocTemplate.new(:smartypants => true) { |t| "OKAY -- 'Smarty Pants'" }
+        assert_equal "<p>OKAY – ‘Smarty Pants’</p>", template.render
+      end
     end
 
     it "stripping HTML when :escape_html is set" do
@@ -29,10 +31,12 @@ begin
     # use markdown_strict => true to disable additional markdown features
     describe "passing in Pandoc options" do
       it "generates footnotes" do
-        template = Tilt::PandocTemplate.new { |t| "Here is an inline note.^[Inlines notes are cool!]" }
-        result = template.render
-        assert_match "Here is an inline note", result
-        assert_match "Inlines notes are cool!", result
+        with_utf8_default_encoding do
+          template = Tilt::PandocTemplate.new { |t| "Here is an inline note.^[Inlines notes are cool!]" }
+          result = template.render
+          assert_match "Here is an inline note", result
+          assert_match "Inlines notes are cool!", result
+        end
       end
 
       it "doesn't generate footnotes with markdown_strict option" do

--- a/test/tilt_rstpandoctemplate_test.rb
+++ b/test/tilt_rstpandoctemplate_test.rb
@@ -20,10 +20,9 @@ begin
       end
     end
 
-    it "doens't use markdown options" do
+    it "supports :escape_html option" do
       template = Tilt::RstPandocTemplate.new(:escape_html => true) { |t| "HELLO <blink>WORLD</blink>" }
-      err = assert_raises(RuntimeError) { template.render }
-      assert_match %r(pandoc: unrecognized option `--escape-html), err.message
+      assert_equal "<p>HELLO &lt;blink&gt;WORLD&lt;/blink&gt;</p>", template.render
     end
   end
 rescue LoadError => boom


### PR DESCRIPTION
This makes sure all template engines other than bluecloth, less, and sigil are tested in CI.  Previously, the erubi and prawn engines were not tested (erubi not listed, prawn needs matrix in Ruby 3.1+).

This fixes some encoding issues in the pandoc tests when UTF-8 is no the default encoding.

This fixes the rst-pandoc template, which has been broken since the require was changed in a168cc9e7ae86c6e9769c4692ee7153b885906ef.  Update the rst-pandoc tests now that the :escape_html option works correctly.