### PR TITLE
Deprecate BlueCloth, Less, and Sigil support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,24 +55,14 @@ group :secondary do
     gem 'matrix'
   end
 
-  # Both rdiscount and bluecloth embeds Discount and loading
-  # both at the same time causes strange issues.
-  discount_gem = ENV["DISCOUNT_GEM"] || "rdiscount"
-  raise "DISCOUNT_GEM must be set to 'rdiscount' or 'bluecloth'" if !%w[rdiscount bluecloth].include?(discount_gem)
-
   platform :ruby do
     gem 'wikicloth'
     gem 'rinku' # dependency for wikicloth for handling links
 
     gem 'yajl-ruby'
     gem 'redcarpet'
-    gem 'rdiscount', '>= 2.1.6' if discount_gem == "rdiscount"
+    gem 'rdiscount', '>= 2.1.6'
     gem 'RedCloth'
     gem 'commonmarker'
   end
-
-  platform :mri do
-    gem 'bluecloth' if discount_gem == "bluecloth"
-  end
 end
-

--- a/lib/tilt/bluecloth.rb
+++ b/lib/tilt/bluecloth.rb
@@ -1,6 +1,8 @@
 require 'tilt/template'
 require 'bluecloth'
 
+warn "Tilt::BlueClothTemplate is deprecated, please switch to a different markdown implementation"
+
 module Tilt
   # BlueCloth Markdown implementation. See:
   # http://deveiate.org/projects/BlueCloth/

--- a/lib/tilt/less.rb
+++ b/lib/tilt/less.rb
@@ -1,6 +1,8 @@
 require 'tilt/template'
 require 'less'
 
+warn "Tilt::LessTemplate is deprecated, consider switching from LESS to SCSS"
+
 module Tilt
   # Lessscss template implementation. See:
   # http://lesscss.org/

--- a/lib/tilt/sigil.rb
+++ b/lib/tilt/sigil.rb
@@ -1,6 +1,8 @@
 require 'open3'
 require 'shellwords'
 
+warn "Tilt::SigilTemplate is deprecated"
+
 module Tilt
   # Standalone string interpolator and template processor implementation in Go.
   # see: https://github.com/gliderlabs/sigil


### PR DESCRIPTION
None of these are tested in CI.

BlueCloth conflicts with RDiscount.  It could theoretically be
tested in CI if RDiscount was in primary templates and BlueCloth
in secondary templates, but considering BlueCloth hasn't had a
release in over 10 years, and Tilt supports many other markdown
formats, there isn't a good reason to keep supporting it.

Less on CRuby depends on therubyracer, which no longer works on
modern Ruby due to changes in Psych.  I tried enabling it in CI,
and it won't install (https://github.com/jeremyevans/tilt/runs/7812514562?check_suite_focus=true#step:4:155).
Less hasn't had a release in over 8 years, and therubyracer hasn't
had a release in over 5 years.

Sigil doesn't have a gem, and isn't even packaged for my operating
system (OpenBSD).  It's possible we could test it in CI if it is
packaged for whatever Linux distro CI uses, but I doubt the usage
of tilt/sigil is high enough to justify that.

If any tilt user really needs these template engines, they can just
copy the related template file and require it manually.