### PR TITLE
Patch unmaintained Slim Template implementation to support sass-embedded

### DIFF
--- a/lib/tilt/mapping.rb
+++ b/lib/tilt/mapping.rb
@@ -270,7 +270,17 @@ module Tilt
     end
 
     def lookup(ext)
-      @template_map[ext] || lazy_load(ext)
+      template = @template_map[ext] || lazy_load(ext)
+
+      # This is the most reliable place to patch Slim::Embedded::SassEngine as the patch must be
+      # loaded after the Slim::Embedded::SassEngine and Tilt::SassTemplate are loaded and before
+      # Slim::Embedded::SassEngine#tilt_render is called.
+      if constant_defined?('Slim::Embedded::SassEngine') && constant_defined?('Tilt::SassTemplate')
+        # Use require_relative to make sure patch file is only loaded once.
+        require_relative 'slim'
+      end
+
+      template
     end
 
     LOCK = Monitor.new

--- a/lib/tilt/slim.rb
+++ b/lib/tilt/slim.rb
@@ -1,0 +1,21 @@
+# Patch unmaintained Slim Template implementation to support sass-embedded.
+# See mapping.rb for how it is loaded.
+module Slim
+  class Embedded
+    # https://github.com/slim-template/slim/blob/v4.1.0/lib/slim/embedded.rb#L148-L161
+    class SassEngine
+      protected
+
+      def tilt_render(tilt_engine, tilt_options, text)
+        is_sass_embedded = tilt_engine <= ::Tilt::SassTemplate && tilt_engine::Engine.nil?
+        text = tilt_engine.new(tilt_options.merge(
+          style: options[:pretty] ? :expanded : :compressed
+        ).merge!(
+          is_sass_embedded ? { charset: false } : { cache: false }
+        )) { text }.render
+        text.chomp! unless text.frozen?
+        [:static, text]
+      end
+    end
+  end
+end

--- a/tilt.gemspec
+++ b/tilt.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |s|
     lib/tilt/rst-pandoc.rb
     lib/tilt/sass.rb
     lib/tilt/sigil.rb
+    lib/tilt/slim.rb
     lib/tilt/string.rb
     lib/tilt/template.rb
     lib/tilt/typescript.rb


### PR DESCRIPTION
First of all, I deeply apologize for such an ugly solution for an ugly problem.

Basically the slim project has been completely abandoned for nearly two years, and recently even the website domain expired. Slim does two things that sass-embedded has a problem with:
1. https://github.com/slim-template/slim/issues/889 - It passes an argument that sass-embedded does not support. Because sass-embedded uses keyword arguments instead of an options hash, it does not tolerate unknown arguments. It is for a good reason so that users won't be able to make typos on options and not know about the typo, but this currently breaks slim tilt sass integration.
2. https://github.com/slim-template/slim/pull/887 - It tries to chomp a frozen string, which will fail. This is a deliberate choice in sass-embedded as the protobuf gem returns a frozen string, and unfrozen it would mean duplicating a potentially large string in memory. Also, dart-sass does not output a newline character at the end of the file, so there is no need to chomp anyways.

The best thing to do is of course if we can update slim, which seems to be impossible. The next thing we can do is to release a gem just include the patch, that user has to manually load it. However, this has a user experience problem because it is hard to make sure gems and files are loaded in correct order, which is why I ended up here.