### PR TITLE
Only add coffee-script in Gemfile in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
 
     env:
       BUNDLE_WITHOUT: ${{ matrix.bundle_without }}
+      COFFEE_SCRIPT: use
     name: Ruby ${{ matrix.ruby }} (${{ matrix.title }})
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :primary do
     gem 'sass-embedded'
   end
 
-  gem 'coffee-script'
+  gem 'coffee-script' if ENV['COFFEE_SCRIPT']
   gem 'livescript'
   gem 'babel-transpiler'
   gem 'typescript-node'


### PR DESCRIPTION
coffee-script is soft-deprecated (no deprecation message, but considered deprecated by the maintainers). Not sure we should deprecate tilt's support, but this makes it so `bundle install` will not attempt to install something considered deprecated.

Fixes #384