### PR TITLE
Add support for Axlsx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ group :secondary do
   gem 'prawn', '>= 2.0.0'
   gem 'pdf-reader'
   gem 'nokogiri'
+  gem 'caxlsx'
+  gem 'roo'
 
   if RUBY_VERSION >= '3.1'
     # Was default library, now bundled gem.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Support for these template engines is included with the package:
 | Babel                   | .es6, .babel, .jsx     | babel-transpiler                           | Tilt team   |
 | Opal                    | .rb                    | opal                                       | Community   |
 | Sigil                   | .sigil                 | sigil                                      | Community   |
+| Axlsx                   | .xlsx, .axlsx          | caxlsx                                     | Community   |
 
 Every supported template engine has a *maintainer*. Note that this is the
 maintainer of the Tilt integration, not the maintainer of the template engine

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -135,6 +135,7 @@ module Tilt
 
   # Rest (sorted by name)
   register_lazy :AsciidoctorTemplate,  'tilt/asciidoc',  'ad', 'adoc', 'asciidoc'
+  register_lazy :AxlsxTemplate,        'tilt/axlsx',     'xlsx', 'axlsx'
   register_lazy :BabelTemplate,        'tilt/babel',     'es6', 'babel', 'jsx'
   register_lazy :BuilderTemplate,      'tilt/builder',   'builder'
   register_lazy :CSVTemplate,          'tilt/csv',       'rcsv'

--- a/lib/tilt/axlsx.rb
+++ b/lib/tilt/axlsx.rb
@@ -1,0 +1,23 @@
+require 'tilt/template'
+require 'axlsx'
+
+module Tilt
+  class AxlsxTemplate < Template
+    self.default_mime_type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+    def prepare
+    end
+
+    def precompiled_preamble(locals)
+      'xlsx_package = ::Axlsx::Package.new'
+    end
+
+    def precompiled_postamble(locals)
+      'xlsx_package.to_stream.string'
+    end
+
+    def precompiled_template(locals)
+      data.to_str
+    end
+  end
+end

--- a/test/tilt_axlsx_test.rb
+++ b/test/tilt_axlsx_test.rb
@@ -1,0 +1,44 @@
+require_relative 'test_helper'
+
+begin
+  require 'tilt/axlsx'
+  require 'roo'
+
+  describe 'tilt/axlsx' do
+    before do
+      @template = Tilt::AxlsxTemplate.new do |t| 
+        <<~TEMPLATE
+          wb = xlsx_package.workbook
+          wb.add_worksheet(name: 'Users') do |sheet|
+            sheet.add_row ["id", "email"]
+          end
+        TEMPLATE
+      end
+    end
+
+    it "is registered for '.xlsx' files" do
+      assert_equal Tilt::AxlsxTemplate, Tilt['test.xlsx']
+    end
+
+    it "is registered for '.axlsx' files" do
+      assert_equal Tilt::AxlsxTemplate, Tilt['test.axlsx']
+    end
+
+    it "compiles and evaluates the template on #render" do
+      output = @template.render
+      wb = Roo::Spreadsheet.open(StringIO.new(output), extension: :xlsx)
+      assert_equal ["Users"], wb.sheets
+      assert_equal ["id", "email"], wb.sheet(0).row(1)
+    end
+
+    it "can be rendered more than once" do
+      3.times do 
+        output = @template.render
+        wb = Roo::Spreadsheet.open(StringIO.new(output), extension: :xlsx)
+        assert_equal ["Users"], wb.sheets
+      end
+    end
+  end
+rescue LoadError
+  warn "Tilt::AxlsxTemplate (disabled)"
+end


### PR DESCRIPTION
Add support for rendering Open Office Spreadsheets using [Caxlsx](https://github.com/caxlsx/caxlsx). "Templating" would be the same as used by [caxlsx_rails](https://github.com/caxlsx/caxlsx_rails#template).