### PR TITLE
Prepare for Tilt 2.1.0 Release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
 
     env:
       BUNDLE_WITHOUT: ${{ matrix.bundle_without }}
+      COFFEE_SCRIPT: use
     name: Ruby ${{ matrix.ruby }} (${{ matrix.title }})
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,15 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
           - "jruby"
-        # … but only the primary templates
+        # but only the primary templates
         bundle_without: ["secondary:development"]
         title: ["primary templates"]
 
         # In addition we test for the secondary templates on the latest version of Ruby
         include:
-          - ruby: "3.1"
+          - ruby: "3.2"
             bundle_without: "primary:development"
             title: "secondary templates"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-## master
+## 2.1.0 (2023-02-17)
+
+* Use UnboundMethod#bind_call on Ruby 2.7+ for better performance (#380, jeremyevans)
+* Add Tilt::Template#freeze_string_literals? for freezing string literals in compiled templates (#301, jeremyevans)
+* Use Haml::Template for Tilt::HamlTemplate if available (Haml 6+) (#391, ntkme) 
+* Deprecate BlueCloth, Less, and Sigil support (#382, jeremyevans)
+* Add Template#compiled_path accessor to save compiled template output to file (#369, jeremyevans)
+* Add Mapping#unregister to remove registered extensions (#376, jeremyevans)
+* Add Mapping#register_pipeline to register template pipelines (#259, jeremyevans)
+* Remove Tilt::Dummy (#364, jeremyevans)
+* Ensure Mapping#extensions\_for returns unique values (#342, mojavelinux)
+* Remove opal support, since the the opal API changed (#374, jeremyevans)
+* Remove .livescript extension for LiveScript (#374, jeremyevans)
+* Set required\_ruby\_version in gemspec (#371, jeremyevans)
 
 ## 2.0.11 (2022-07-22)
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :primary do
     gem 'sass-embedded'
   end
 
-  gem 'coffee-script'
+  gem 'coffee-script' if ENV['COFFEE_SCRIPT']
   gem 'livescript'
   gem 'babel-transpiler'
   gem 'typescript-node'

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 Tilt [![Test suite](https://github.com/rtomayko/tilt/actions/workflows/test.yml/badge.svg)](https://github.com/rtomayko/tilt/actions/workflows/test.yml) [![Inline docs](http://inch-ci.org/github/rtomayko/tilt.svg)](http://inch-ci.org/github/rtomayko/tilt)
 ====
 
-**NOTE** The following file documents the current release of Tilt (2.0). See
-https://github.com/rtomayko/tilt/tree/tilt-1 for documentation for Tilt 1.4.
-
 Tilt is a thin interface over a bunch of different Ruby template engines in
 an attempt to make their usage as generic as possible. This is useful for web
 frameworks, static site generators, and other systems that support multiple
@@ -34,12 +31,10 @@ Support for these template engines is included with the package:
 | Haml                    | .haml                  | haml                                       | Tilt team   |
 | Sass                    | .sass                  | sass-embedded (>= 1.0) or sassc (>=2.0)    | Tilt team   |
 | Scss                    | .scss                  | sass-embedded (>= 1.0) or sassc (>=2.0)    | Tilt team   |
-| Less CSS                | .less                  | less                                       | Tilt team   |
 | Builder                 | .builder               | builder                                    | Tilt team   |
 | Liquid                  | .liquid                | liquid                                     | Community   |
 | RDiscount               | .markdown, .mkd, .md   | rdiscount                                  | Community   |
 | Redcarpet               | .markdown, .mkd, .md   | redcarpet                                  | Community   |
-| BlueCloth               | .markdown, .mkd, .md   | bluecloth                                  | Community   |
 | Kramdown                | .markdown, .mkd, .md   | kramdown                                   | Community   |
 | Pandoc                  | .markdown, .mkd, .md   | pandoc                                     | Community   |
 | reStructuredText        | .rst                   | pandoc                                     | Community   |
@@ -57,11 +52,10 @@ Support for these template engines is included with the package:
 | Creole (Wiki markup)    | .wiki, .creole         | creole                                     | Community   |
 | WikiCloth (Wiki markup) | .wiki, .mediawiki, .mw | wikicloth                                  | Community   |
 | Yajl                    | .yajl                  | yajl-ruby                                  | Community   |
-| CSV                     | .rcsv                  | none (Ruby >= 1.9), fastercsv (Ruby < 1.9) | Tilt team   |
+| CSV                     | .rcsv                  | none (included ruby stdlib)                | Tilt team   |
 | Prawn                   | .prawn                 | prawn (>= 2.0.0)                           | Community   |
 | Babel                   | .es6, .babel, .jsx     | babel-transpiler                           | Tilt team   |
 | Opal                    | .rb                    | opal                                       | Community   |
-| Sigil                   | .sigil                 | sigil                                      | Community   |
 
 Every supported template engine has a *maintainer*. Note that this is the
 maintainer of the Tilt integration, not the maintainer of the template engine
@@ -69,14 +63,17 @@ itself. The maintainer is responsible for providing an adequate integration and
 keeping backwards compatibility across Tilt version. Some integrations are
 maintained by the *community*, which is handled in the following way:
 
-- The Tilt team will liberally accept pull requests against the template
-  integration. It's up to the community as a whole to make sure the integration
-  stays consistent and backwards compatible over time.
+- The Tilt team will liberally accept pull requests to update existing
+  community-maintained template integrations. It's up to the community as a
+  whole to make sure the integration stays consistent and backwards compatible
+  over time.
 - Test failures in community-maintained integrations will not be prioritized by
   the Tilt team and a new version of Tilt might be released even though these
   tests are failing.
 - Anyone can become a maintainer for a template engine integration they care
   about. Just open an issue and we'll figure it out.
+- The Tilt team is no longer accepting new community-maintained template
+  integrations.
 
 These template engines ship with their own Tilt integration:
 
@@ -243,7 +240,7 @@ it on subsequent template invocations. Benchmarks show this yields a 5x-10x
 performance increase over evaluating the Ruby source on each invocation.
 
 Template compilation is currently supported for these template engines:
-StringTemplate, ERB, Erubis, Haml, Nokogiri, Builder and Yajl.
+StringTemplate, ERB, Erubis, Erubi, Haml, Nokogiri, Builder and Yajl.
 
 LICENSE
 -------

--- a/Rakefile
+++ b/Rakefile
@@ -60,25 +60,3 @@ if defined?(Gem)
     mv File.basename(f.name), f.name
   end
 end
-
-# GEMSPEC ===================================================================
-
-file 'tilt.gemspec' => FileList['{lib,test}/**','Rakefile'] do |f|
-  # read version from tilt.rb
-  version = File.read('lib/tilt.rb')[/VERSION = '(.*)'/] && $1
-  # read spec file and split out manifest section
-  spec = File.
-    read(f.name).
-    sub(/s\.version\s*=\s*'.*'/, "s.version = '#{version}'")
-  parts = spec.split("  # = MANIFEST =\n")
-  # determine file list from git ls-files
-  files = `git ls-files -- lib bin COPYING`.
-    split("\n").sort.reject{ |file| file =~ /^\./ }.
-    map{ |file| "    #{file}" }.join("\n")
-  # piece file back together and write...
-  parts[1] = "  s.files = %w[\n#{files}\n  ]\n"
-  spec = parts.join("  # = MANIFEST =\n")
-  spec.sub!(/s.date = '.*'/, "s.date = '#{Time.now.strftime("%Y-%m-%d")}'")
-  File.open(f.name, 'w') { |io| io.write(spec) }
-  puts "updated #{f.name}"
-end

--- a/lib/tilt.rb
+++ b/lib/tilt.rb
@@ -4,7 +4,7 @@ require_relative 'tilt/template'
 # Namespace for Tilt. This module is not intended to be included anywhere.
 module Tilt
   # Current version.
-  VERSION = '2.0.11'
+  VERSION = '2.1.0'
 
   @default_mapping = Mapping.new
 

--- a/lib/tilt/erb.rb
+++ b/lib/tilt/erb.rb
@@ -19,6 +19,7 @@ module Tilt
     end
 
     def prepare
+      @freeze_string_literals = !!@options[:freeze]
       @outvar = options[:outvar] || self.class.default_output_variable
       trim = case options[:trim]
       when false
@@ -62,6 +63,10 @@ module Tilt
     def precompiled(locals)
       source, offset = super
       [source, offset + 1]
+    end
+
+    def freeze_string_literals?
+      @freeze_string_literals
     end
   end
 end

--- a/lib/tilt/erubi.rb
+++ b/lib/tilt/erubi.rb
@@ -16,6 +16,24 @@ module Tilt
 
       engine_class = @options[:engine_class] || Erubi::Engine
 
+      # If :freeze option is given, the intent is to setup frozen string
+      # literals in the template.  So enable frozen string literals in the
+      # code Tilt generates if the :freeze option is given.
+      if @freeze_string_literals = !!@options[:freeze]
+        # Passing the :freeze option to Erubi sets the
+        # frozen-string-literal magic comment, which doesn't have an effect
+        # with Tilt as Tilt wraps the resulting code.  Worse, the magic
+        # comment appearing not at the top of the file can cause a warning.
+        # So remove the :freeze option before passing to Erubi.
+        @options.delete(:freeze)
+
+        # Erubi by default appends .freeze to template literals on Ruby 2.1+,
+        # but that is not necessary and slows down code when Tilt is using
+        # frozen string literals, so pass the :freeze_template_literals
+        # option to not append .freeze.
+        @options[:freeze_template_literals] = false
+      end
+
       @engine = engine_class.new(data, @options)
       @outvar = @engine.bufvar
 
@@ -27,6 +45,10 @@ module Tilt
 
     def precompiled_template(locals)
       @src
+    end
+
+    def freeze_string_literals?
+      @freeze_string_literals
     end
   end
 end

--- a/lib/tilt/erubis.rb
+++ b/lib/tilt/erubis.rb
@@ -16,6 +16,7 @@ module Tilt
   #                   within <%= %> blocks will be automatically html escaped.
   class ErubisTemplate < ERBTemplate
     def prepare
+      @freeze_string_literals = !!@options.delete(:freeze)
       @outvar = options.delete(:outvar) || self.class.default_output_variable
       @options.merge!(:preamble => false, :postamble => false, :bufvar => @outvar)
       engine_class = options.delete(:engine_class)
@@ -36,6 +37,10 @@ module Tilt
     def precompiled(locals)
       source, offset = super
       [source, offset - 1]
+    end
+
+    def freeze_string_literals?
+      @freeze_string_literals
     end
   end
 end

--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -274,8 +274,13 @@ module Tilt
         method_source.force_encoding(source.encoding)
       end
 
+      if freeze_string_literals?
+        method_source << "# frozen-string-literal: true\n"
+      end
+
       # Don't indent method source, to avoid indentation warnings when using compiled paths
       method_source << "::Tilt::TOPOBJECT.class_eval do\ndef #{method_name}(locals)\n#{local_code}\n"
+
       offset += method_source.count("\n")
       method_source << source
       method_source << "\nend;end;"
@@ -335,6 +340,10 @@ module Tilt
       binary(script) do
         script[/\A[ \t]*\#.*coding\s*[=:]\s*([[:alnum:]\-_]+).*$/n, 1]
       end
+    end
+
+    def freeze_string_literals?
+      false
     end
 
     def binary(string)

--- a/test/tilt_erbtemplate_test.rb
+++ b/test/tilt_erbtemplate_test.rb
@@ -225,6 +225,13 @@ describe 'tilt/erb (compiled)' do
     3.times { assert_equal 'UTF-8', erb.render(self).encoding.to_s }
     f.delete
   end
+
+  if RUBY_VERSION >= '2.3'
+    it "uses frozen literal strings if :freeze option is used" do
+      template = Tilt::ERBTemplate.new(nil, :freeze => true) { |t| %(<%= "".frozen? %>) }
+      assert_equal "true", template.render
+    end
+  end
 end
 
 __END__

--- a/test/tilt_erubistemplate_test.rb
+++ b/test/tilt_erubistemplate_test.rb
@@ -138,6 +138,13 @@ begin
       Tilt::ErubisTemplate.new(nil, options_hash) { |t| "Hello World!" }
       assert_equal({:escape_html => true}, options_hash)
     end
+
+    if RUBY_VERSION >= '2.3'
+      it "uses frozen literal strings if :freeze option is used" do
+        template = Tilt::ErubisTemplate.new(nil, :freeze => true) { |t| %(<%= "".frozen? %>) }
+        assert_equal "true", template.render
+      end
+    end
   end
 rescue LoadError
   warn "Tilt::ErubisTemplate (disabled)"

--- a/test/tilt_erubitemplate_test.rb
+++ b/test/tilt_erubitemplate_test.rb
@@ -141,6 +141,13 @@ begin
       Tilt::ErubiTemplate.new(nil, options_hash) { |t| "Hello World!" }
       assert_equal({:escape_html => true}, options_hash)
     end
+
+    if RUBY_VERSION >= '2.3'
+      it "uses frozen literal strings if :freeze option is used" do
+        template = Tilt::ErubiTemplate.new(nil, :freeze => true) { |t| %(<%= "".frozen? %>) }
+        assert_equal "true", template.render
+      end
+    end
   end
 rescue LoadError
   warn "Tilt::ErubiTemplate (disabled)"

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -311,8 +311,28 @@ describe "tilt/template" do
     assert_equal inst2, $inst2
     assert_nil Tilt.current_template
   end
+
+  if RUBY_VERSION >= '2.3'
+    _FrozenStringMockTemplate = Class.new(_PreparingMockTemplate) do
+      def freeze_string_literals?
+        true
+      end
+      def precompiled_template(locals)
+        "'bar'"
+      end
+    end
+
+    it "uses frozen literal strings if freeze_literal_strings? is true" do
+      inst = _FrozenStringMockTemplate.new{|d| 'a'}
+      assert_equal "bar", inst.render
+      assert_equal true, inst.render.frozen?
+      assert inst.prepared?
+    end
+  end
 end
 
+  ##
+  # Encodings
 describe "tilt/template (encoding)" do
   _DynamicMockTemplate = Class.new(_MockTemplate) do
     def precompiled_template(locals)

--- a/tilt.gemspec
+++ b/tilt.gemspec
@@ -1,61 +1,17 @@
+require './lib/tilt'
+
 Gem::Specification.new do |s|
   s.name = 'tilt'
-  s.version = '2.0.11'
-  s.date = '2022-07-22'
+  s.version = Tilt::VERSION
 
   s.description = "Generic interface to multiple Ruby template engines"
   s.summary     = s.description
   s.license     = "MIT"
 
-  s.authors = ["Ryan Tomayko"]
+  s.authors = ["Ryan Tomayko", "Magnus Holm", "Jeremy Evans"]
   s.email = "r@tomayko.com"
 
-  # = MANIFEST =
-  s.files = %w[
-    COPYING
-    bin/tilt
-    lib/tilt.rb
-    lib/tilt/asciidoc.rb
-    lib/tilt/babel.rb
-    lib/tilt/bluecloth.rb
-    lib/tilt/builder.rb
-    lib/tilt/coffee.rb
-    lib/tilt/commonmarker.rb
-    lib/tilt/creole.rb
-    lib/tilt/csv.rb
-    lib/tilt/dummy.rb
-    lib/tilt/erb.rb
-    lib/tilt/erubi.rb
-    lib/tilt/erubis.rb
-    lib/tilt/etanni.rb
-    lib/tilt/haml.rb
-    lib/tilt/kramdown.rb
-    lib/tilt/less.rb
-    lib/tilt/liquid.rb
-    lib/tilt/livescript.rb
-    lib/tilt/mapping.rb
-    lib/tilt/markaby.rb
-    lib/tilt/maruku.rb
-    lib/tilt/nokogiri.rb
-    lib/tilt/pandoc.rb
-    lib/tilt/plain.rb
-    lib/tilt/prawn.rb
-    lib/tilt/radius.rb
-    lib/tilt/rdiscount.rb
-    lib/tilt/rdoc.rb
-    lib/tilt/redcarpet.rb
-    lib/tilt/redcloth.rb
-    lib/tilt/rst-pandoc.rb
-    lib/tilt/sass.rb
-    lib/tilt/sigil.rb
-    lib/tilt/string.rb
-    lib/tilt/template.rb
-    lib/tilt/typescript.rb
-    lib/tilt/wikicloth.rb
-    lib/tilt/yajl.rb
-  ]
-  # = MANIFEST =
-
+  s.files = %w'COPYING bin/tilt' + Dir["lib/**/*.rb"]
   s.executables = ['tilt']
 
   s.homepage = "https://github.com/rtomayko/tilt/"


### PR DESCRIPTION
@judofyr since I know you are busy, this:

* Combines the #301, #380, #385, #393 pull requests (and also fixes issues #384, #390)
* Updates CI to include Ruby 3.2
* Updates the CHANGELOG
* Makes it so you do not need to regenerate the gemspec
* Bumps version to 2.1.0

After merging, you should be able to build the 2.1.0 gem for release.

Hopefully you can add also me as a gem owner and we can move the repository to something we can control.  There is still significant work I want to do on tilt, such as increasing test coverage, and it would be much easier if I had the ability to merge PRs or push.