### PR TITLE
Support Commonmarker v1 api

### DIFF
--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -5,69 +5,47 @@ module Tilt
   class CommonMarkerTemplate < Template
     self.default_mime_type = 'text/html'
 
-    OPTION_ALIAS = {
-      :smartypants => :SMART
-    }
     PARSE_OPTIONS = [
-      :FOOTNOTES,
-      :LIBERAL_HTML_TAG,
-      :SMART,
-      :smartypants,
-      :STRIKETHROUGH_DOUBLE_TILDE,
-      :UNSAFE,
-      :VALIDATE_UTF8,
+      :smart,
+      :default_info_string,
     ].freeze
     RENDER_OPTIONS = [
-      :FOOTNOTES,
-      :FULL_INFO_STRING,
-      :GITHUB_PRE_LANG,
-      :HARDBREAKS,
-      :NOBREAKS,
-      :SAFE, # Removed in v0.18.0 (2018-10-17)
-      :SOURCEPOS,
-      :TABLE_PREFER_STYLE_ATTRIBUTES,
-      :UNSAFE,
+      :hardbreaks,
+      :github_pre_lang,
+      :width,
+      :unsafe,
+      :escape,
+      :sourcepos
     ].freeze
     EXTENSIONS = [
-      :autolink,
       :strikethrough,
-      :table,
       :tagfilter,
+      :table,
+      :autolink,
       :tasklist,
+      :superscript,
+      :header_ids,
+      :footnotes,
+      :description_lists,
+      :front_matter_delimiter,
+      :shortcodes,
     ].freeze
 
     def extensions
-      EXTENSIONS.select do |extension|
-        options[extension]
+      @options.select do |key, _value|
+        EXTENSIONS.include?(key)
       end
     end
 
     def parse_options
-      raw_options = PARSE_OPTIONS.select do |option|
-        options[option]
-      end
-      actual_options = raw_options.map do |option|
-        OPTION_ALIAS[option] || option
-      end
-
-      if actual_options.any?
-        actual_options
-      else
-        :DEFAULT
+      @options.select do |key, _value|
+        PARSE_OPTIONS.include?(key)
       end
     end
 
     def render_options
-      raw_options = RENDER_OPTIONS.select do |option|
-        options[option]
-      end
-      actual_options = raw_options.map do |option|
-        OPTION_ALIAS[option] || option
-      end
-      if actual_options.any?
-        actual_options
-      else
-        :DEFAULT
+      @options.select do |key, _value|
+        RENDER_OPTIONS.include?(key)
       end
     end
 
@@ -77,8 +55,7 @@ module Tilt
     end
 
     def evaluate(scope, locals, &block)
-      doc = CommonMarker.render_doc(data, parse_options, extensions)
-      doc.to_html(render_options, extensions)
+      Commonmarker.to_html(data, options: { parse: parse_options, render: render_options, extension: extensions })
     end
 
     def allows_script?

--- a/test/tilt_commonmarkertemplate_test.rb
+++ b/test/tilt_commonmarkertemplate_test.rb
@@ -15,14 +15,14 @@ begin
     end
 
     it "smartypants when :smartypants is set" do
-      template = Tilt::CommonMarkerTemplate.new(:smartypants => true) do |t|
+      template = Tilt::CommonMarkerTemplate.new(smart: true) do |t|
         "OKAY -- 'Smarty Pants'"
       end
       assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
     end
 
-    it 'Renders unsafe HTML when :UNSAFE is set' do
-      template = Tilt::CommonMarkerTemplate.new(UNSAFE: true) do |_t|
+    it 'Renders unsafe HTML when :unsafe is set' do
+      template = Tilt::CommonMarkerTemplate.new(unsafe: true) do |_t|
         <<~MARKDOWN
           <div class="alert alert-info full-width">
             <h5 class="card-title">TL;DR</h5>
@@ -42,6 +42,13 @@ begin
       EXPECTED_HTML
 
       assert_match(expected, template.render)
+    end
+
+    it "autolinking when :autolink is set" do
+      template = Tilt::CommonMarkerTemplate.new(autolink: true) do |t|
+        "https://example.com"
+      end
+      assert_match('<a href="https://example.com">https://example.com</a>', template.render)
     end
   end
 rescue LoadError


### PR DESCRIPTION
## What

The Commonmarker gem released v1 incluging breaking api changes. 
https://github.com/gjtorikian/commonmarker/releases/tag/v1.0.0

These changes supports the new commonmarker's api.

To support commonmaker's breaking api changes, tilt gem will release new version including incompatible api change also.
For notice to tilt gem user, is it better to check commonmarker gem's version?